### PR TITLE
[DG22-1840] - Update Estimator UI for PDRS Rule 2b 

### DIFF
--- a/src/components/calculate/CalculateBlock.js
+++ b/src/components/calculate/CalculateBlock.js
@@ -5,6 +5,14 @@ import DateInput from 'components/form_elements/DateInput';
 import FormTextInput from 'components/form_elements/FormTextInput';
 import DropDownMenu from 'components/form_elements/DropDownMenu';
 import RadioButton from 'components/form_elements/RadioButton';
+import {
+  BESS1_PDRSDec24_installation_location,
+  BESS1_PDRSDec24_inverter_installed,
+  BESS1_PDRSDec24_inverter_warranty,
+  BESS1_PDRSDec24_smoke_alarm,
+  F16_electric_PDRSDec24__storage_volume,
+  F16_electric_PDRSDec24__certified,
+} from 'types/openfisca_variables';
 
 export default function CalculateBlock(props) {
   const {
@@ -56,8 +64,6 @@ export default function CalculateBlock(props) {
     console.log(zone);
   }
 
-  console.log('form values', formValues);
-
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
@@ -70,9 +76,6 @@ export default function CalculateBlock(props) {
   const renderFormField = (formItem) => {
     var arr = [];
     arr = formValues.map((x) => ({ ...x }));
-
-    console.log(dependencies);
-    console.log(formValues);
 
     if (
       formItem.name === 'Base_meets_mandatory_requirement' &&
@@ -204,6 +207,22 @@ export default function CalculateBlock(props) {
     }
 
     const setItemValue = (e) => {
+      if (formItem.name === BESS1_PDRSDec24_inverter_installed) {
+        if (e.target.value === 'true') {
+          formValues.find((v) => v.name === BESS1_PDRSDec24_inverter_warranty).hide = false;
+        } else if (e.target.value === 'false') {
+          formValues.find((v) => v.name === BESS1_PDRSDec24_inverter_warranty).hide = true;
+        }
+      }
+
+      if (formItem.name === BESS1_PDRSDec24_installation_location) {
+        if (e.target.value === 'installed_outdoors') {
+          formValues.find((v) => v.name === BESS1_PDRSDec24_smoke_alarm).hide = true;
+        } else if (e.target.value === 'installed_indoors') {
+          formValues.find((v) => v.name === BESS1_PDRSDec24_smoke_alarm).hide = false;
+        }
+      }
+
       if (formItem.name === 'SYS2_multiple_speed') {
         if (e.target.value === 'true') {
           formValues.find((v) => v.name === 'SYS2_single_speed_input_power').hide = true;
@@ -480,11 +499,11 @@ export default function CalculateBlock(props) {
         }
       }
 
-      if (formItem.name === 'WH1_F16_electric_PDRSAug24__storage_volume') {
-        if (e.target.value === 'less_than_425_L' || e.target.value === 'equal_425_L_to_700_L') {
-          formValues.find((v) => v.name === 'WH1_F16_electric_PDRSAug24__certified').hide = false;
+      if (formItem.name === F16_electric_PDRSDec24__storage_volume) {
+        if (e.target.value === 'true') {
+          formValues.find((v) => v.name === F16_electric_PDRSDec24__certified).hide = false;
         } else {
-          formValues.find((v) => v.name === 'WH1_F16_electric_PDRSAug24__certified').hide = true;
+          formValues.find((v) => v.name === F16_electric_PDRSDec24__certified).hide = true;
         }
       }
 

--- a/src/pages/BESS1/ActivityRequirementsBESS1.jsx
+++ b/src/pages/BESS1/ActivityRequirementsBESS1.jsx
@@ -11,7 +11,8 @@ import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
 import LoadClausesBESS1 from './LoadClausesActReq';
 import {
-  BESS1_V5Nov24_installation_final_activity_eligibility,
+  BESS1_PDRSDec24_installation_final_activity_eligibility,
+  BESS1_PDRSDec24_smoke_alarm,
   HVAC2_ACOP_eligible,
   HVAC2_AEER_greater_than_minimum,
   HVAC2_equipment_replaced,
@@ -29,7 +30,7 @@ export default function ActivityRequirementsBESS1(props) {
   const [stepNumber, setStepNumber] = useState(1);
   const [dependencies, setDependencies] = useState([]);
   const [variableToLoad, setVariableToLoad] = useState(
-    BESS1_V5Nov24_installation_final_activity_eligibility,
+    BESS1_PDRSDec24_installation_final_activity_eligibility,
   );
   const [clausesForm, setClausesForm] = useState([]);
   const [showError, setShowError] = useState(false);
@@ -95,6 +96,7 @@ export default function ActivityRequirementsBESS1(props) {
         HVAC2_HSPF_mixed_eligible,
         HVAC2_HSPF_cold_eligible,
         HVAC2_ACOP_eligible,
+        BESS1_PDRSDec24_smoke_alarm,
       ];
 
       dep_arr = array.filter((item) => names.includes(item.name));

--- a/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
@@ -11,8 +11,8 @@ import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
 import LoadClausesWH1 from './LoadClausesWh';
 import {
   F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility,
-  F16_electric_PDRSDec24__certified
-} from 'types/openfisca_variables'
+  F16_electric_PDRSDec24__certified,
+} from 'types/openfisca_variables';
 
 export default function ActivityRequirementsWH1(props) {
   const { entities, variables, setEntities, setVariables, loading, setLoading } = props;
@@ -21,7 +21,7 @@ export default function ActivityRequirementsWH1(props) {
   const [stepNumber, setStepNumber] = useState(1);
   const [dependencies, setDependencies] = useState([]);
   const [variableToLoad, setVariableToLoad] = useState(
-    F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility
+    F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility,
   );
   const [clausesForm, setClausesForm] = useState([]);
   const [showError, setShowError] = useState(false);

--- a/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
@@ -9,6 +9,10 @@ import OpenFiscaAPI from 'services/openfisca_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
 import LoadClausesWH1 from './LoadClausesWh';
+import {
+  F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility,
+  F16_electric_PDRSDec24__certified
+} from 'types/openfisca_variables'
 
 export default function ActivityRequirementsWH1(props) {
   const { entities, variables, setEntities, setVariables, loading, setLoading } = props;
@@ -17,7 +21,7 @@ export default function ActivityRequirementsWH1(props) {
   const [stepNumber, setStepNumber] = useState(1);
   const [dependencies, setDependencies] = useState([]);
   const [variableToLoad, setVariableToLoad] = useState(
-    'WH1_F16_electric_PDRSAug24__installation_replacement_final_activity_eligibility',
+    F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility
   );
   const [clausesForm, setClausesForm] = useState([]);
   const [showError, setShowError] = useState(false);
@@ -89,7 +93,7 @@ export default function ActivityRequirementsWH1(props) {
 
       console.log(array);
 
-      const names = ['WH1_F16_electric_PDRSAug24__certified'];
+      const names = [F16_electric_PDRSDec24__certified];
 
       dep_arr = array.filter((item) => names.includes(item.name));
 

--- a/src/pages/commercial_wh/LoadClausesWh.jsx
+++ b/src/pages/commercial_wh/LoadClausesWh.jsx
@@ -13,6 +13,7 @@ import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progres
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
+import {F16_electric_PDRSDec24__storage_volume} from 'types/openfisca_variables'
 
 export default function LoadClausesWH1(props) {
   const {
@@ -91,7 +92,7 @@ export default function LoadClausesWH1(props) {
   };
 
   const filteredClausesForm = clausesForm.filter(
-    (item) => !(item.name === 'WH1_F16_electric_PDRSAug24__storage_volume'),
+    (item) => !(item.name === F16_electric_PDRSDec24__storage_volume),
   );
 
   if (!variable) return null;
@@ -217,7 +218,7 @@ export default function LoadClausesWH1(props) {
                             <br />
                             <div className="nsw-global-alert__title">
                               {item.metadata.display_question}:{' '}
-                              {item.name === 'WH1_F16_electric_PDRSAug24__storage_volume'
+                              {item.name === F16_electric_PDRSDec24__storage_volume
                                 ? formatStorageVolume(item.form_value)
                                 : item.value_type === 'Boolean'
                                 ? formatBooleanToString(item.form_value)

--- a/src/pages/commercial_wh/LoadClausesWh.jsx
+++ b/src/pages/commercial_wh/LoadClausesWh.jsx
@@ -13,7 +13,7 @@ import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progres
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
-import {F16_electric_PDRSDec24__storage_volume} from 'types/openfisca_variables'
+import { F16_electric_PDRSDec24__storage_volume } from 'types/openfisca_variables';
 
 export default function LoadClausesWH1(props) {
   const {

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -19,6 +19,8 @@ export const BESS1_V5Nov24_installation_final_activity_eligibility =
   'BESS1_V5Nov24_installation_final_activity_eligibility';
 export const BESS2_V5Nov24_installation_final_activity_eligibility =
   'BESS2_V5Nov24_installation_final_activity_eligibility';
+export const BESS1_PDRSDec24_installation_final_activity_eligibility =
+  'BESS1_PDRSDec24_installation_final_activity_eligibility';
 
 export const BESS1_V5Nov24_peak_demand_annual_savings = 'BESS1_V5Nov24_peak_demand_annual_savings';
 export const BESS2_V5Nov24_peak_demand_annual_savings = 'BESS2_V5Nov24_peak_demand_annual_savings';
@@ -33,4 +35,14 @@ export const HVAC2_HSPF_cold_eligible = 'HVAC2_HSPF_cold_eligible';
 export const HVAC2_ACOP_eligible = 'HVAC2_ACOP_eligible';
 
 export const BESS1_V5Nov24_usable_battery_capacity = 'BESS1_V5Nov24_usable_battery_capacity';
+export const BESS1_PDRSDec24_inverter_installed = 'BESS1_PDRSDec24_inverter_installed';
+export const BESS1_PDRSDec24_inverter_warranty = 'BESS1_PDRSDec24_inverter_warranty';
+export const BESS1_PDRSDec24_installation_location = 'BESS1_PDRSDec24_installation_location';
+export const BESS1_PDRSDec24_smoke_alarm = 'BESS1_PDRSDec24_smoke_alarm';
 export const BESS2_V5Nov24_usable_battery_capacity = 'BESS2_V5Nov24_usable_battery_capacity';
+
+// Water heater electric (F16)
+export const F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility =
+  'F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility'
+export const F16_electric_PDRSDec24__storage_volume = 'F16_electric_PDRSDec24__storage_volume'
+export const F16_electric_PDRSDec24__certified = 'F16_electric_PDRSDec24__certified'

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -43,6 +43,6 @@ export const BESS2_V5Nov24_usable_battery_capacity = 'BESS2_V5Nov24_usable_batte
 
 // Water heater electric (F16)
 export const F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility =
-  'F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility'
-export const F16_electric_PDRSDec24__storage_volume = 'F16_electric_PDRSDec24__storage_volume'
-export const F16_electric_PDRSDec24__certified = 'F16_electric_PDRSDec24__certified'
+  'F16_electric_PDRSDec24__installation_replacement_final_activity_eligibility';
+export const F16_electric_PDRSDec24__storage_volume = 'F16_electric_PDRSDec24__storage_volume';
+export const F16_electric_PDRSDec24__certified = 'F16_electric_PDRSDec24__certified';


### PR DESCRIPTION
# [DG22-1840] - Update Estimator UI for PDRS Rule 2b

## Summary
This pull request addresses the following functionality/fixes:
* Change openfisca variable that being used for BESS1 and F16 eligibility

## Technical changes
This is a summary of technical changes to the codebase.
* update openfisca variable to use pdrs dec 2024 in commercial water heater eligibility (F16) and residential solar battery installation (BESS1)

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-1840

**Screenshots**
- None 

## Pre deployment tasks
- [ ] update database variables on django openfisca API with run command `python3 manage.py fetch_variable` on vm

## Post deployment tasks
- [ ] Testing and validate eligibility for commercial water heater eligibility (F16) and residential solar battery activity (BESS1)

[DG22-1840]: https://essnsw.atlassian.net/browse/DG22-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ