### PR TITLE
[DG22-1840] Update Estimator UI for PDRS Rule 2b

### DIFF
--- a/src/components/calculate/CalculateBlock.js
+++ b/src/components/calculate/CalculateBlock.js
@@ -8,7 +8,7 @@ import RadioButton from 'components/form_elements/RadioButton';
 import {
   BESS1_PDRSDec24_installation_location,
   BESS1_PDRSDec24_inverter_installed,
-  BESS1_PDRSDec24_inverter_warranty,
+  BESS1_PDRSDec24_inverter_warranty_length_eligible,
   BESS1_PDRSDec24_smoke_alarm,
   F16_electric_PDRSDec24__storage_volume,
   F16_electric_PDRSDec24__certified,
@@ -206,12 +206,25 @@ export default function CalculateBlock(props) {
       ).hide = true;
     }
 
+    if (formItem.name === F16_electric_PDRSDec24__storage_volume && formItem.form_value === true) {
+      formValues.find((v) => v.name === F16_electric_PDRSDec24__certified).hide = false;
+    } else if (
+      formItem.name === F16_electric_PDRSDec24__storage_volume &&
+      formItem.form_value === false
+    ) {
+      formValues.find((v) => v.name === F16_electric_PDRSDec24__certified).hide = true;
+    }
+
     const setItemValue = (e) => {
       if (formItem.name === BESS1_PDRSDec24_inverter_installed) {
         if (e.target.value === 'true') {
-          formValues.find((v) => v.name === BESS1_PDRSDec24_inverter_warranty).hide = false;
+          formValues.find(
+            (v) => v.name === BESS1_PDRSDec24_inverter_warranty_length_eligible,
+          ).hide = false;
         } else if (e.target.value === 'false') {
-          formValues.find((v) => v.name === BESS1_PDRSDec24_inverter_warranty).hide = true;
+          formValues.find(
+            (v) => v.name === BESS1_PDRSDec24_inverter_warranty_length_eligible,
+          ).hide = true;
         }
       }
 

--- a/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
@@ -86,7 +86,7 @@ export default function ActivityRequirementsWH1(props) {
       var dep_arr = [];
 
       children.map((child) => {
-        array.push({ ...child, form_value: '', invalid: false, hide: false });
+        array.push({ ...child, form_value: child.default_value, invalid: false, hide: false });
       });
 
       array.sort((a, b) => a.metadata.sorting - b.metadata.sorting);
@@ -168,13 +168,6 @@ export default function ActivityRequirementsWH1(props) {
                   target="_blank"
                 >
                   Energy Savings Scheme
-                </a>{' '}
-                and WH1 in the{' '}
-                <a
-                  href="https://www.energy.nsw.gov.au/nsw-plans-and-progress/regulation-and-policy/energy-security-safeguard/peak-demand-reduction-scheme"
-                  target="_blank"
-                >
-                  Peak Demand Reduction Scheme
                 </a>
                 ). This activity is for replacement of an existing electric water heater with an
                 (air source) heat pump water heater.

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -289,7 +289,7 @@ export default function CertificateEstimatorLoadClausesWH(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -298,10 +298,6 @@ export default function CertificateEstimatorLoadClausesWH(props) {
                   </span>
                   {/* </h4> */}
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
-                  and your PRCs are
-                  <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult)}</b>
-                  </span>
                   {/* </h4> */}
                 </p>
                 <p>
@@ -311,17 +307,6 @@ export default function CertificateEstimatorLoadClausesWH(props) {
                       {Math.floor(calculationResult2) === 0
                         ? 0
                         : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
-                </p>
-                <p>
-                  Your estimated annual peak demand reduction is{' '}
-                  <b>
-                    <b>
-                      {Math.floor(calculationResult) === 0
-                        ? 0
-                        : Math.round(peakDemandReductionSavingsNumber * 100) / 100}
                     </b>{' '}
                     kWh{' '}
                   </b>

--- a/src/pages/commercial_wh/CertificateEstimatorWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorWH.jsx
@@ -223,23 +223,16 @@ export default function CertificateEstimatorWH(props) {
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-10">
               <p className="nsw-content-block__copy">
-                Estimate the energy savings certificates (ESCs) and peak reduction certificates
-                (PRCs) for the commercial heat pump water heater activity (F16 in the{' '}
+                Estimate the energy savings certificates (ESCs) for the commercial heat pump water
+                heater activity (F16 in the{' '}
                 <a
                   href="https://www.energy.nsw.gov.au/nsw-plans-and-progress/regulation-and-policy/energy-security-safeguard/energy-savings-scheme"
                   target="_blank"
                 >
                   Energy Savings Scheme
-                </a>{' '}
-                and WH1 in the{' '}
-                <a
-                  href="https://www.energy.nsw.gov.au/nsw-plans-and-progress/regulation-and-policy/energy-security-safeguard/peak-demand-reduction-scheme"
-                  target="_blank"
-                >
-                  Peak Demand Reduction Scheme
                 </a>
                 ) by answering the following questions. Note that a new installation activity will
-                not generate ESCs or PRCs.
+                not generate ESCs.
               </p>
               <p className="nsw-content-block__copy">
                 At the end of each week, commercial heat pump water heater specifications are

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -36,9 +36,10 @@ export const HVAC2_ACOP_eligible = 'HVAC2_ACOP_eligible';
 
 export const BESS1_V5Nov24_usable_battery_capacity = 'BESS1_V5Nov24_usable_battery_capacity';
 export const BESS1_PDRSDec24_inverter_installed = 'BESS1_PDRSDec24_inverter_installed';
-export const BESS1_PDRSDec24_inverter_warranty = 'BESS1_PDRSDec24_inverter_warranty';
 export const BESS1_PDRSDec24_installation_location = 'BESS1_PDRSDec24_installation_location';
 export const BESS1_PDRSDec24_smoke_alarm = 'BESS1_PDRSDec24_smoke_alarm';
+export const BESS1_PDRSDec24_inverter_warranty_length_eligible =
+  'BESS1_PDRSDec24_inverter_warranty_length_eligible';
 export const BESS2_V5Nov24_usable_battery_capacity = 'BESS2_V5Nov24_usable_battery_capacity';
 
 // Water heater electric (F16)


### PR DESCRIPTION
# [DG22-1840] - Update Estimator UI for PDRS Rule 2b

## Summary
This pull request addresses the following functionality/fixes:
* bug fixing on bess1 eligibility form
* bug fixing on f16 eligibility form
* Adjust copy on f16 eligibility, certificate and result page to remove WH1 and PRC

## Technical changes
This is a summary of technical changes to the codebase.
* use openfisca variable `BESS1_PDRSDec24_inverter_warranty_length_eligible` on bess1 eligibility form
* adjust default value on f16 eligibility form
* adjust copy on f16 eligibility, certificate and result page to remove WH1 and PRC text

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-1840

**Screenshots**
- None 

## Pre deployment tasks
- update database variables on django openfisca API with run command `python3 manage.py fetch_variables` on vm

## Post deployment tasks
- Testing and validate eligibility for commercial water heater eligibility (F16) and residential solar battery activity

[DG22-1840]: https://essnsw.atlassian.net/browse/DG22-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ