### PR TITLE
[DG22-2296] streamline white space gap in all eligibility pages

### DIFF
--- a/src/pages/BESS1/ActivityRequirementsBESS1.jsx
+++ b/src/pages/BESS1/ActivityRequirementsBESS1.jsx
@@ -23,11 +23,11 @@ import {
   updateEstimatorFormAnalytics,
   updateFeedbackFormAnalytics,
   updateSegmentCaptureAnalytics,
-  clearSearchCaptureAnalytics,
+  clearSearchCaptureAnalytics
 } from 'lib/analytics';
 import FeedbackComponent from 'components/feedback/feedback';
 import MoreOptionsCard from 'components/more-options-card/more-options-card';
-import { BASE_BESS1_ELIGIBILITY_ANALYTICS_DATA } from 'constant/base-analytics-data';
+import {BASE_BESS1_ELIGIBILITY_ANALYTICS_DATA} from 'constant/base-analytics-data';
 
 export default function ActivityRequirementsBESS1(props) {
   const { entities, variables, loading, setLoading } = props;
@@ -141,7 +141,7 @@ export default function ActivityRequirementsBESS1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -196,7 +196,7 @@ export default function ActivityRequirementsBESS1(props) {
                   label="What is your interest in the scheme?"
                   helper="Select the option that best describes you"
                   htmlId="user-type"
-                  style={{ marginTop: '4%' }}
+                  style={{marginTop: '4%'}}
                 >
                   <Select
                     htmlId="user-type"

--- a/src/pages/BESS2/ActivityRequirementsBESS2.jsx
+++ b/src/pages/BESS2/ActivityRequirementsBESS2.jsx
@@ -138,7 +138,7 @@ export default function ActivityRequirementsBESS2(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/base_eligibility/BaseEligibility.jsx
+++ b/src/pages/base_eligibility/BaseEligibility.jsx
@@ -137,7 +137,7 @@ export default function BaseEligibility(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
+++ b/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsCommercialAC(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_motors/ActivityRequirementsSYS1.jsx
+++ b/src/pages/commercial_motors/ActivityRequirementsSYS1.jsx
@@ -13,11 +13,11 @@ import {
   updateEstimatorFormAnalytics,
   updateFeedbackFormAnalytics,
   updateSegmentCaptureAnalytics,
-  clearSearchCaptureAnalytics,
+  clearSearchCaptureAnalytics
 } from 'lib/analytics';
 import FeedbackComponent from 'components/feedback/feedback';
 import MoreOptionsCard from 'components/more-options-card/more-options-card';
-import { BASE_COMMERCIAL_MOTOR_ELIGIBILITY_ANALYTICS_DATA } from 'constant/base-analytics-data';
+import {BASE_COMMERCIAL_MOTOR_ELIGIBILITY_ANALYTICS_DATA} from 'constant/base-analytics-data';
 
 export default function ActivityRequirementsSYS1(props) {
   const { entities, variables, loading, setLoading } = props;
@@ -111,7 +111,7 @@ export default function ActivityRequirementsSYS1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -167,7 +167,7 @@ export default function ActivityRequirementsSYS1(props) {
                   label="What is your interest in the scheme?"
                   helper="Select the option that best describes you"
                   htmlId="user-type"
-                  style={{ marginTop: '4%' }}
+                  style={{marginTop: '4%'}}
                 >
                   <Select
                     htmlId="user-type"

--- a/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
@@ -132,7 +132,7 @@ export default function ActivityRequirementsWH1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh_F16_gas/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh_F16_gas/ActivityRequirementsWaterHeater.jsx
@@ -125,7 +125,7 @@ export default function ActivityRequirementsF16_gas(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh_f17/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh_f17/ActivityRequirementsWaterHeater.jsx
@@ -125,7 +125,7 @@ export default function ActivityRequirementsF17(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/electric_residential_heat_pumps/ActivityRequirementsD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/ActivityRequirementsD17.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD17(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/gas_residential_heat_pumps/ActivityRequirementsD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/ActivityRequirementsD19.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD19(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
+++ b/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
@@ -126,7 +126,9 @@ export default function ActivityRequirementsSYS2(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
+        <br></br>
+        <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-12">

--- a/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
+++ b/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
@@ -131,7 +131,7 @@ export default function ActivityRequirementsRF2(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_ac/ActivityRequirementsResAC.jsx
+++ b/src/pages/residential_ac/ActivityRequirementsResAC.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsResAC(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
+++ b/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
@@ -109,7 +109,7 @@ export default function ActivityRequirementsRF1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_solar_water_heater_D18/ActivityRequirementsD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/ActivityRequirementsD18.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsD18(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/ActivityRequirementsD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/ActivityRequirementsD20.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD20(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (


### PR DESCRIPTION
# [DG22-2296] streamline white space gap in all eligibility pages

## Summary
This pull request addresses the following functionality/fixes:
* streamline white space gap in all eligibility pages and use certificate page white space as reference.

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2296

**Screenshots**
- None 

## Pre deployment tasks
- 

## Post deployment tasks
- 

[DG22-2296]: https://essnsw.atlassian.net/browse/DG22-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ