### PR TITLE
[DG22-1946] add certificate price to all certificate pages except residential ac

### DIFF
--- a/src/components/certificate-price/CertificiatePrice.js
+++ b/src/components/certificate-price/CertificiatePrice.js
@@ -10,10 +10,10 @@ export default function CertificiatePrice(props) {
     prcMaxPrice = 0
   } = props;
 
-  const esc_calculation_min_price = Math.floor(escCertificates * escMinPrice)
-  const esc_calculation_max_price = Math.floor(escCertificates * escMaxPrice)
-  const prc_calculation_min_price = Math.floor(prcCertificates * prcMinPrice)
-  const prc_calculation_max_price = Math.floor(prcCertificates * prcMaxPrice)
+  const esc_calculation_min_price = Math.floor(Math.floor(escCertificates) * escMinPrice)
+  const esc_calculation_max_price = Math.floor(Math.floor(escCertificates) * escMaxPrice)
+  const prc_calculation_min_price = Math.floor(Math.floor(prcCertificates) * prcMinPrice)
+  const prc_calculation_max_price = Math.floor(Math.floor(prcCertificates) * prcMaxPrice)
 
   return (
     <>
@@ -36,7 +36,7 @@ export default function CertificiatePrice(props) {
             <div className={ prcCertificates > 0 ? `nsw-container nsw-m-bottom-lg` : ''} style={{ paddingLeft: 0, paddingRight: 0 }}>
               <Alert
                 as="info"
-                title={`Potential ESCs Incentives $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
+                title={`Potential ESCs incentive $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
                 style={{ marginTop: 0 }}
               >
                 <p>
@@ -51,7 +51,7 @@ export default function CertificiatePrice(props) {
             <div className="nsw-container" style={{ paddingLeft: 0, paddingRight: 0 }}>
               <Alert
                 as="info"
-                title={`Potential PRCs Incentives $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
+                title={`Potential PRCs incentive $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
                 style={{ marginTop: 0 }}
               >
                 <p>

--- a/src/pages/BESS1/CertificateEstimatorBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorBESS1.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesBESS1 from './CertificateEstimatorLoadClausesBESS1';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -42,6 +43,8 @@ export default function CertificateEstimatorBESS1(props) {
   const [selectedModel, setSelectedModel] = useState(null);
   const [postcode, setPostcode] = useState(null);
   const [userType, setUserType] = useState('');
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -91,6 +94,20 @@ export default function CertificateEstimatorBESS1(props) {
         console.log(err);
       });
   }, [variables, entities]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setPrcMinPrice(Number(response.data.ESC.min_price))
+        setPrcMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -201,6 +218,8 @@ export default function CertificateEstimatorBESS1(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -237,6 +256,8 @@ export default function CertificateEstimatorBESS1(props) {
               setShowError={setShowError}
               userType={userType}
               setUserType={setUserType}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
         </Fragment>

--- a/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
@@ -11,6 +11,7 @@ import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesBESS1(props) {
   const {
@@ -50,6 +51,8 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -194,7 +197,7 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -244,11 +247,15 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginBottom: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/BESS2/CertificateEstimatorBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorBESS2.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesBESS2 from './CertificateEstimatorLoadClausesBESS2';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -42,6 +43,8 @@ export default function CertificateEstimatorBESS2(props) {
   const [selectedModel, setSelectedModel] = useState(null);
   const [postcode, setPostcode] = useState(null);
   const [userType, setUserType] = useState('');
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -91,6 +94,20 @@ export default function CertificateEstimatorBESS2(props) {
         console.log(err);
       });
   }, [variables, entities]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setPrcMinPrice(Number(response.data.ESC.min_price))
+        setPrcMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -201,6 +218,8 @@ export default function CertificateEstimatorBESS2(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -237,6 +256,8 @@ export default function CertificateEstimatorBESS2(props) {
               setShowError={setShowError}
               userType={userType}
               setUserType={setUserType}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
         </Fragment>

--- a/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
@@ -11,6 +11,7 @@ import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesBESS2(props) {
   const {
@@ -50,6 +51,8 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -194,7 +197,7 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -244,11 +247,15 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginBottom: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClauses(props) {
   const {
@@ -47,6 +48,10 @@ export default function CertificateEstimatorLoadClauses(props) {
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
     selectedClimateZone,
+    escMinPrice,
+    escMaxPrice,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   const bca_mapping = {
@@ -284,7 +289,7 @@ export default function CertificateEstimatorLoadClauses(props) {
               </div>
             </div>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -345,11 +350,18 @@ export default function CertificateEstimatorLoadClauses(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -54,6 +54,10 @@ export default function CertificateEstimatorHVAC(props) {
   const [selectedClimateZone, setSelectedClimateZone] = useState('');
   const [dropdownOptionsClimateZone, setDropdownOptionsClimateZone] = useState([]);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -104,6 +108,22 @@ export default function CertificateEstimatorHVAC(props) {
       setPeakDemandReductionSavingsNumber(0);
     }
   }, [peakDemandReductionSavingsNumber]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   // For brands
   const populateDropDown = (newOption) => {
@@ -550,6 +570,10 @@ export default function CertificateEstimatorHVAC(props) {
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               selectedClimateZone={selectedClimateZone}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -588,6 +612,10 @@ export default function CertificateEstimatorHVAC(props) {
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               selectedClimateZone={selectedClimateZone}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
@@ -10,7 +10,8 @@ import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
-import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import {updateSegmentCaptureAnalytics} from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesMotors(props) {
   const {
@@ -47,6 +48,8 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -184,7 +187,7 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -228,11 +231,15 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
@@ -3,6 +3,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesMotors from './CertificateEstimatorLoadClausesMotors';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -42,6 +43,8 @@ export default function CertificateEstimatorMotors(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -92,6 +95,20 @@ export default function CertificateEstimatorMotors(props) {
         console.log(err);
       });
   }, [variables, entities]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -202,6 +219,8 @@ export default function CertificateEstimatorMotors(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -238,6 +257,8 @@ export default function CertificateEstimatorMotors(props) {
               setShowError={setShowError}
               userType={userType}
               setUserType={setUserType}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesWH(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesWH(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -263,7 +266,7 @@ export default function CertificateEstimatorLoadClausesWH(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -309,11 +312,15 @@ export default function CertificateEstimatorLoadClausesWH(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_wh/CertificateEstimatorWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorWH.jsx
@@ -53,6 +53,8 @@ export default function CertificateEstimatorWH(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -204,6 +206,20 @@ export default function CertificateEstimatorWH(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -401,6 +417,8 @@ export default function CertificateEstimatorWH(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -460,6 +478,8 @@ export default function CertificateEstimatorWH(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
@@ -48,6 +48,8 @@ export default function CertificateEstimatorF16_gas(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -197,6 +199,20 @@ export default function CertificateEstimatorF16_gas(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -407,6 +423,8 @@ export default function CertificateEstimatorF16_gas(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -466,6 +484,8 @@ export default function CertificateEstimatorF16_gas(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesF16_gas(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -263,7 +266,7 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -306,11 +309,15 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorF17(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -198,6 +200,20 @@ export default function CertificateEstimatorF17(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -410,6 +426,8 @@ export default function CertificateEstimatorF17(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -469,6 +487,8 @@ export default function CertificateEstimatorF17(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesF17(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesF17(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -257,7 +260,7 @@ export default function CertificateEstimatorLoadClausesF17(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -300,11 +303,15 @@ export default function CertificateEstimatorLoadClausesF17(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorElectricHeatPump(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -87,6 +89,20 @@ export default function CertificateEstimatorElectricHeatPump(props) {
       setShowPostcodeError(false);
     }
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   RegistryApi.getResidentialHeatPumpLastModified()
     .then((res) => {
@@ -417,6 +433,8 @@ export default function CertificateEstimatorElectricHeatPump(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -476,6 +494,8 @@ export default function CertificateEstimatorElectricHeatPump(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesD17(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesD17(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -258,7 +261,7 @@ export default function CertificateEstimatorLoadClausesD17(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -308,11 +311,15 @@ export default function CertificateEstimatorLoadClausesD17(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorGasHeatPump(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -200,6 +202,20 @@ export default function CertificateEstimatorGasHeatPump(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -419,6 +435,8 @@ export default function CertificateEstimatorGasHeatPump(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -476,6 +494,8 @@ export default function CertificateEstimatorGasHeatPump(props) {
               setFlow={setFlow}
               loading={loading}
               setLoading={setLoading}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesD19(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesD19(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -256,7 +259,7 @@ export default function CertificateEstimatorLoadClausesD19(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -306,11 +309,15 @@ export default function CertificateEstimatorLoadClausesD19(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesPP(props) {
   const {
@@ -46,6 +47,10 @@ export default function CertificateEstimatorLoadClausesPP(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   useEffect(() => {
@@ -268,7 +273,7 @@ export default function CertificateEstimatorLoadClausesPP(props) {
               </div>
             </div>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -330,11 +335,18 @@ export default function CertificateEstimatorLoadClausesPP(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+               <CertificiatePrice
+                prcCertificates={calculationResult}
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/pool_pumps/CertificateEstimatorPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorPP.jsx
@@ -56,6 +56,10 @@ export default function CertificateEstimatorPP(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     if (annualEnergySavingsNumber < 0) {
@@ -85,6 +89,22 @@ export default function CertificateEstimatorPP(props) {
           console.log(err);
         });
     }
+  }, []);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
   }, []);
 
   // For brands
@@ -418,6 +438,10 @@ export default function CertificateEstimatorPP(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -455,6 +479,10 @@ export default function CertificateEstimatorPP(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesRC(props) {
   const {
@@ -47,6 +48,10 @@ export default function CertificateEstimatorLoadClausesRC(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   useEffect(() => {
@@ -251,7 +256,7 @@ export default function CertificateEstimatorLoadClausesRC(props) {
               </div>
             </div>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -312,11 +317,18 @@ export default function CertificateEstimatorLoadClausesRC(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
@@ -50,6 +50,10 @@ export default function CertificateEstimatorRC(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     if (annualEnergySavingsNumber < 0) {
@@ -119,6 +123,22 @@ export default function CertificateEstimatorRC(props) {
       setShowPostcodeError(false);
     }
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   if (lastModified.length == 0) {
     RegistryApi.getRF2LastModified()
@@ -452,6 +472,10 @@ export default function CertificateEstimatorRC(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -491,6 +515,10 @@ export default function CertificateEstimatorRC(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -368,7 +368,7 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 prcMinPrice={prcMinPrice}
                 prcMaxPrice={prcMaxPrice}
               />
-              <div className="nsw-col-md-9" style={{marginTop: '1.5rem'}}>
+              <div className="nsw-col-md-9" style={{marginTop: '1.25rem'}}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
@@ -12,6 +12,7 @@ import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from '../../nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesRefrigerators(props) {
   const {
@@ -48,6 +49,8 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   useEffect(() => {
@@ -177,7 +180,7 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -226,11 +229,15 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesRefrigerators from './CertificateEstimatorLoadClausesRefrigerators';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -40,6 +41,8 @@ export default function CertificateEstimatorRefrigerators(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -88,6 +91,20 @@ export default function CertificateEstimatorRefrigerators(props) {
       .catch((err) => {
         console.log(err);
       });
+  }, []);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
   }, []);
 
   return (
@@ -203,6 +220,8 @@ export default function CertificateEstimatorRefrigerators(props) {
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               userType={userType}
               setUserType={setUserType}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -239,6 +258,8 @@ export default function CertificateEstimatorRefrigerators(props) {
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               userType={userType}
               setUserType={setUserType}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -202,6 +204,20 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -413,6 +429,8 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -472,6 +490,8 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
               setLoading={setLoading}
               showError={showError}
               setShowError={setShowError}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesD18(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesD18(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -257,7 +260,7 @@ export default function CertificateEstimatorLoadClausesD18(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -306,11 +309,15 @@ export default function CertificateEstimatorLoadClausesD18(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -201,6 +203,20 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -413,6 +429,8 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -472,6 +490,8 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
               setLoading={setLoading}
               showError={showError}
               setShowError={setShowError}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
@@ -8,6 +8,8 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+
 
 export default function CertificateEstimatorLoadClausesD20(props) {
   const {
@@ -46,6 +48,8 @@ export default function CertificateEstimatorLoadClausesD20(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -255,7 +259,7 @@ export default function CertificateEstimatorLoadClausesD20(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -304,11 +308,15 @@ export default function CertificateEstimatorLoadClausesD20(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"


### PR DESCRIPTION
# [DG22-1946] add certificate price to all certificate pages except residential ac

## Summary
This pull request addresses the following functionality/fixes:
* Add certificate price at result page to all certificate page except residential ac

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-1946

**Screenshots**
- None 

## Pre deployment tasks
- 

## Post deployment tasks
- 

[DG22-1946]: https://essnsw.atlassian.net/browse/DG22-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ