### PR TITLE
[DG22-2323] Add postcode and product registry info to all steps in certificate pages

### DIFF
--- a/src/components/calculate/CalculateBlock.js
+++ b/src/components/calculate/CalculateBlock.js
@@ -57,6 +57,7 @@ export default function CalculateBlock(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    setPostcode,
   } = props;
 
   useEffect(() => {
@@ -701,6 +702,7 @@ export default function CalculateBlock(props) {
       setCalculationError2={setCalculationError2}
       stepNumber={stepNumber}
       setStepNumber={setStepNumber}
+      setPostcode={setPostcode}
       dependencies={dependencies}
       workflow={workflow}
       selectedBrand={selectedBrand}

--- a/src/components/calculate/CalculateForm.js
+++ b/src/components/calculate/CalculateForm.js
@@ -70,6 +70,7 @@ export default function CalculateForm(props) {
     showError,
     setShowError,
     postcode,
+    setPostcode,
     annualEnergySavings,
     peakDemandReductionSavings,
     annualEnergySavingsNumber,
@@ -367,6 +368,7 @@ export default function CalculateForm(props) {
                     setShowPostcodeError(false);
                     setFlow(null);
                     setStepNumber(stepNumber + 1);
+                    setPostcode(variable.form_value);
                     updatePostCodeAnalytics(variable.form_value);
                     submitEstimatorFormAnalytics();
                   } else {

--- a/src/components/form_elements/FormTextInput.jsx
+++ b/src/components/form_elements/FormTextInput.jsx
@@ -16,7 +16,6 @@ export default function FormTextInput(props) {
       className={`${formItem.hide ? 'nsw-display-none' : ''}`}
     >
       <TextInput
-        htmlId={formItem.name}
         style={{ maxWidth: '50%', marginBottom: '4%' }}
         as="input"
         number={['Float', 'Integer'].includes(formItem.value_type)}

--- a/src/components/form_elements/FormTextInput.jsx
+++ b/src/components/form_elements/FormTextInput.jsx
@@ -13,8 +13,10 @@ export default function FormTextInput(props) {
       label={formItem.metadata.label} // helper text (secondary label)
       error="Invalid value!" // error text if invalid
       status={formItem.invalid && 'invalid'} // if `true` renders invalid formatting
+      className={`${formItem.hide ? 'nsw-display-none' : ''}`}
     >
       <TextInput
+        htmlId={formItem.name}
         style={{ maxWidth: '50%', marginBottom: '4%' }}
         as="input"
         number={['Float', 'Integer'].includes(formItem.value_type)}

--- a/src/pages/BESS1/CertificateEstimatorBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorBESS1.jsx
@@ -207,6 +207,7 @@ export default function CertificateEstimatorBESS1(props) {
               selectedBrand={selectedBrand}
               selectedModel={selectedModel}
               postcode={postcode}
+              setPostcode={setPostcode}
               flow={flow}
               setFlow={setFlow}
               loading={loading}
@@ -244,6 +245,7 @@ export default function CertificateEstimatorBESS1(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
@@ -33,6 +33,7 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
     selectedBrand,
     selectedModel,
     postcode,
+    setPostcode,
     flow,
     setFlow,
     persistFormValues,
@@ -168,6 +169,7 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -196,6 +198,20 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                </div>
+              </div>
+            </div>
             {
               <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
@@ -206,8 +206,7 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
               <div className="nsw-global-alert__wrapper">
                 <div className="nsw-global-alert__content">
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                 </div>
               </div>

--- a/src/pages/BESS2/CertificateEstimatorBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorBESS2.jsx
@@ -207,6 +207,7 @@ export default function CertificateEstimatorBESS2(props) {
               selectedBrand={selectedBrand}
               selectedModel={selectedModel}
               postcode={postcode}
+              setPostcode={setPostcode}
               flow={flow}
               setFlow={setFlow}
               loading={loading}
@@ -244,6 +245,7 @@ export default function CertificateEstimatorBESS2(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
@@ -33,6 +33,7 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
     selectedBrand,
     selectedModel,
     postcode,
+    setPostcode,
     flow,
     setFlow,
     persistFormValues,
@@ -168,6 +169,7 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -196,6 +198,20 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                </div>
+              </div>
+            </div>
             {
               <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
@@ -206,8 +206,7 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
               <div className="nsw-global-alert__wrapper">
                 <div className="nsw-global-alert__content">
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                 </div>
               </div>

--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -9,7 +9,10 @@ import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
-
+import {
+  HVAC2_PDRSAug24_PDRS__postcode,
+  HVAC2_PDRSAug24_BCA_Climate_Zone
+} from 'types/openfisca_variables';
 export default function CertificateEstimatorLoadClauses(props) {
   const {
     variableToLoad1,
@@ -171,12 +174,12 @@ export default function CertificateEstimatorLoadClauses(props) {
         ) {
           formItem.form_value = metadata['Rated ACOP'];
         }
-        if (formItem.name === 'HVAC2_PDRSAug24_PDRS__postcode') {
+        if (formItem.name === HVAC2_PDRSAug24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
         }
-        if (formItem.name === 'HVAC2_PDRSAug24_BCA_Climate_Zone') {
+        if (formItem.name === HVAC2_PDRSAug24_BCA_Climate_Zone) {
           formItem.form_value = bca_mapping[selectedClimateZone];
           formItem.read_only = true;
           formItem.hide = true;
@@ -214,20 +217,15 @@ export default function CertificateEstimatorLoadClauses(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>BCA Climate Zone: </b>{' '}
-                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                    <b>BCA Climate Zone: </b> {selectedClimateZone.charAt(selectedClimateZone.length - 1)}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>

--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -174,10 +174,12 @@ export default function CertificateEstimatorLoadClauses(props) {
         if (formItem.name === 'HVAC2_PDRSAug24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
         if (formItem.name === 'HVAC2_PDRSAug24_BCA_Climate_Zone') {
           formItem.form_value = bca_mapping[selectedClimateZone];
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -211,6 +213,15 @@ export default function CertificateEstimatorLoadClauses(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                  <p>
+                    {' '}
+                    <b>BCA Climate Zone: </b>{' '}
+                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -277,6 +288,15 @@ export default function CertificateEstimatorLoadClauses(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                  <p>
+                    {' '}
+                    <b>BCA Climate Zone: </b>{' '}
+                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -594,6 +594,7 @@ export default function CertificateEstimatorHVAC(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
@@ -197,8 +197,7 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
               <div className="nsw-global-alert__wrapper">
                 <div className="nsw-global-alert__content">
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                 </div>
               </div>

--- a/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
@@ -50,6 +50,8 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
     setUserType,
     escMinPrice,
     escMaxPrice,
+    postcode,
+    setPostcode,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -158,6 +160,7 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -186,6 +189,21 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                </div>
+              </div>
+            </div>
+
             {
               <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
@@ -204,6 +204,8 @@ export default function CertificateEstimatorMotors(props) {
               setCalculationError2={setCalculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
+              setPostcode={setPostcode}
               persistFormValues={persistFormValues}
               setPersistFormValues={setPersistFormValues}
               formValues={formValues}
@@ -245,6 +247,7 @@ export default function CertificateEstimatorMotors(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
@@ -264,23 +264,6 @@ export default function CertificateEstimatorMotors(props) {
               escMaxPrice={escMaxPrice}
             />
           )}
-
-          {stepNumber === 1 && registryData && postcode && postcode.length === 4 && (
-            <div className="nsw-row" style={{ paddingTop: '30px' }}>
-              <div className="nsw-col" style={{ padding: 'inherit', width: '80%' }}>
-                <Button
-                  as="dark"
-                  onClick={(e) => {
-                    setFlow('forward');
-                    setStepNumber(stepNumber + 1);
-                  }}
-                  style={{ float: 'right' }}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
-          )}
         </Fragment>
       </div>
       {stepNumber === 2 && (

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -143,6 +143,7 @@ export default function CertificateEstimatorLoadClausesWH(props) {
         if (formItem.name === 'F16_electric_PDRSDec24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -185,6 +186,10 @@ export default function CertificateEstimatorLoadClausesWH(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -250,6 +255,10 @@ export default function CertificateEstimatorLoadClausesWH(props) {
             <div class="nsw-global-alert__wrapper">
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
+                <p>
+                  {' '}
+                  <b>Postcode: </b> {postcode}{' '}
+                </p>
                 <p>
                   {' '}
                   <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {F16_electric_PDRSDec24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesWH(props) {
   const {
@@ -140,7 +141,7 @@ export default function CertificateEstimatorLoadClausesWH(props) {
         // if (formItem.name === 'WH1_WH_capacity_factor') {
         //   formItem.form_value = metadata['WHCap'];
         // }
-        if (formItem.name === 'F16_electric_PDRSDec24_PDRS__postcode') {
+        if (formItem.name === F16_electric_PDRSDec24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -187,15 +188,12 @@ export default function CertificateEstimatorLoadClausesWH(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -256,15 +254,12 @@ export default function CertificateEstimatorLoadClausesWH(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Postcode: </b> {postcode}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Brand: </b> {selectedBrand}
                 </p>
                 <p>
-                  {' '}
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/commercial_wh/CertificateEstimatorWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorWH.jsx
@@ -462,6 +462,7 @@ export default function CertificateEstimatorWH(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
@@ -468,6 +468,7 @@ export default function CertificateEstimatorF16_gas(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
@@ -143,6 +143,7 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
         if (formItem.name === 'F16_gas_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -185,6 +186,10 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -250,6 +255,10 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
             <div class="nsw-global-alert__wrapper">
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
+                <p>
+                  {' '}
+                  <b>Postcode: </b> {postcode}{' '}
+                </p>
                 <p>
                   {' '}
                   <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {F16_gas_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesF16_gas(props) {
   const {
@@ -140,7 +141,7 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
         // if (formItem.name === 'WH1_WH_capacity_factor') {
         //   formItem.form_value = metadata['WHCap'];
         // }
-        if (formItem.name === 'F16_gas_PDRS__postcode') {
+        if (formItem.name === F16_gas_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -187,15 +188,12 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -256,15 +254,12 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Postcode: </b> {postcode}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Brand: </b> {selectedBrand}
                 </p>
                 <p>
-                  {' '}
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
@@ -471,6 +471,7 @@ export default function CertificateEstimatorF17(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {F17_ESS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesF17(props) {
   const {
@@ -134,7 +135,7 @@ export default function CertificateEstimatorLoadClausesF17(props) {
         // if (formItem.name === 'WH1_WH_capacity_factor') {
         //   formItem.form_value = metadata['WHCap'];
         // }
-        if (formItem.name === 'F17_ESS__postcode') {
+        if (formItem.name === F17_ESS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -181,15 +182,12 @@ export default function CertificateEstimatorLoadClausesF17(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -250,15 +248,12 @@ export default function CertificateEstimatorLoadClausesF17(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Postcode: </b> {postcode}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Brand: </b> {selectedBrand}
                 </p>
                 <p>
-                  {' '}
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
@@ -137,6 +137,7 @@ export default function CertificateEstimatorLoadClausesF17(props) {
         if (formItem.name === 'F17_ESS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -179,6 +180,10 @@ export default function CertificateEstimatorLoadClausesF17(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -244,6 +249,10 @@ export default function CertificateEstimatorLoadClausesF17(props) {
             <div class="nsw-global-alert__wrapper">
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
+                <p>
+                  {' '}
+                  <b>Postcode: </b> {postcode}{' '}
+                </p>
                 <p>
                   {' '}
                   <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
@@ -476,6 +476,7 @@ export default function CertificateEstimatorElectricHeatPump(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
@@ -138,6 +138,7 @@ export default function CertificateEstimatorLoadClausesD17(props) {
         if (formItem.name === 'D17_ESSJun24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -180,6 +181,10 @@ export default function CertificateEstimatorLoadClausesD17(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -245,6 +250,10 @@ export default function CertificateEstimatorLoadClausesD17(props) {
             <div class="nsw-global-alert__wrapper">
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
+                <p>
+                  {' '}
+                  <b>Postcode: </b> {postcode}{' '}
+                </p>
                 <p>
                   {' '}
                   <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D17_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesD17(props) {
   const {
@@ -135,7 +136,7 @@ export default function CertificateEstimatorLoadClausesD17(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D17_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D17_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -182,15 +183,12 @@ export default function CertificateEstimatorLoadClausesD17(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -251,15 +249,12 @@ export default function CertificateEstimatorLoadClausesD17(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Postcode: </b> {postcode}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Brand: </b> {selectedBrand}
                 </p>
                 <p>
-                  {' '}
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
@@ -484,6 +484,7 @@ export default function CertificateEstimatorGasHeatPump(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
@@ -136,6 +136,7 @@ export default function CertificateEstimatorLoadClausesD19(props) {
         if (formItem.name === 'D19_ESSJun24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -178,6 +179,10 @@ export default function CertificateEstimatorLoadClausesD19(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -243,6 +248,10 @@ export default function CertificateEstimatorLoadClausesD19(props) {
             <div class="nsw-global-alert__wrapper">
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
+                <p>
+                  {' '}
+                  <b>Postcode: </b> {postcode}{' '}
+                </p>
                 <p>
                   {' '}
                   <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D19_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesD19(props) {
   const {
@@ -133,7 +134,7 @@ export default function CertificateEstimatorLoadClausesD19(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D19_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D19_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -180,15 +181,12 @@ export default function CertificateEstimatorLoadClausesD19(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -249,15 +247,12 @@ export default function CertificateEstimatorLoadClausesD19(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Postcode: </b> {postcode}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Brand: </b> {selectedBrand}
                 </p>
                 <p>
-                  {' '}
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {SYS2_PDRSAug24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesPP(props) {
   const {
@@ -159,7 +160,7 @@ export default function CertificateEstimatorLoadClausesPP(props) {
           formItem.form_value = metadata['labelled_energy_consumption'];
         }
 
-        if (formItem.name === 'SYS2_PDRSAug24_PDRS__postcode') {
+        if (formItem.name === SYS2_PDRSAug24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -197,15 +198,12 @@ export default function CertificateEstimatorLoadClausesPP(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -267,15 +265,12 @@ export default function CertificateEstimatorLoadClausesPP(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -162,6 +162,7 @@ export default function CertificateEstimatorLoadClausesPP(props) {
         if (formItem.name === 'SYS2_PDRSAug24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -195,6 +196,10 @@ export default function CertificateEstimatorLoadClausesPP(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -261,6 +266,10 @@ export default function CertificateEstimatorLoadClausesPP(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/pool_pumps/CertificateEstimatorPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorPP.jsx
@@ -460,6 +460,7 @@ export default function CertificateEstimatorPP(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -133,6 +133,7 @@ export default function CertificateEstimatorLoadClausesRC(props) {
         if (formItem.name === 'RF2_F1_2_ESSJun24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
 
         if (formItem.name === 'RF2_F1_2_ESSJun24_duty_class') {
@@ -179,6 +180,10 @@ export default function CertificateEstimatorLoadClausesRC(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -244,6 +249,10 @@ export default function CertificateEstimatorLoadClausesRC(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {RF2_F1_2_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesRC(props) {
   const {
@@ -130,7 +131,7 @@ export default function CertificateEstimatorLoadClausesRC(props) {
         if (formItem.name === 'RF2_F1_2_ESSJun24_total_energy_consumption') {
           formItem.form_value = metadata['total_energy_consumption'];
         }
-        if (formItem.name === 'RF2_F1_2_ESSJun24_PDRS__postcode') {
+        if (formItem.name === RF2_F1_2_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -181,15 +182,12 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -250,15 +248,12 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>

--- a/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
@@ -495,6 +495,7 @@ export default function CertificateEstimatorRC(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
@@ -577,6 +577,7 @@ export default function CertificateEstimatorResidentialAC(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {HVAC1_PDRSAug24_PDRS__postcode, HVAC1_PDRSAug24_BCA_Climate_Zone} from '../../types/openfisca_variables';
 
 export default function CertificateEstimatorResidentialACLoadClauses(props) {
   const {
@@ -177,12 +178,12 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
         ) {
           formItem.form_value = metadata['Rated ACOP'];
         }
-        if (formItem.name === 'HVAC1_PDRSAug24_PDRS__postcode') {
+        if (formItem.name === HVAC1_PDRSAug24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
         }
-        if (formItem.name === 'HVAC1_PDRSAug24_BCA_Climate_Zone') {
+        if (formItem.name === HVAC1_PDRSAug24_BCA_Climate_Zone) {
           formItem.form_value = bca_mapping[selectedClimateZone];
           formItem.read_only = true;
           formItem.hide = true;
@@ -221,20 +222,15 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>BCA Climate Zone: </b>{' '}
-                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                    <b>BCA Climate Zone: </b> {selectedClimateZone.charAt(selectedClimateZone.length - 1)}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -295,20 +291,15 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>BCA Climate Zone: </b>{' '}
-                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                    <b>BCA Climate Zone: </b> {selectedClimateZone.charAt(selectedClimateZone.length - 1)}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -180,10 +180,12 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
         if (formItem.name === 'HVAC1_PDRSAug24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
         if (formItem.name === 'HVAC1_PDRSAug24_BCA_Climate_Zone') {
           formItem.form_value = bca_mapping[selectedClimateZone];
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -218,6 +220,15 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                  <p>
+                    {' '}
+                    <b>BCA Climate Zone: </b>{' '}
+                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -283,6 +294,15 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                  <p>
+                    {' '}
+                    <b>BCA Climate Zone: </b>{' '}
+                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
@@ -190,8 +190,7 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
               <div className="nsw-global-alert__wrapper">
                 <div className="nsw-global-alert__content">
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                 </div>
               </div>

--- a/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
@@ -22,6 +22,8 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
     entities,
     setStepNumber,
     stepNumber,
+    postcode,
+    setPostcode,
     metadata,
     calculationError,
     calculationError2,
@@ -151,6 +153,7 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -179,6 +182,20 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                </div>
+              </div>
+            </div>
             {
               <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
@@ -199,6 +199,8 @@ export default function CertificateEstimatorRefrigerators(props) {
               setCalculationError2={setCalculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
+              setPostcode={setPostcode}
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
@@ -240,6 +242,7 @@ export default function CertificateEstimatorRefrigerators(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
@@ -265,26 +265,6 @@ export default function CertificateEstimatorRefrigerators(props) {
               escMaxPrice={escMaxPrice}
             />
           )}
-
-          {stepNumber === 1 && registryData && postcode && postcode.length === 4 && (
-            <div className="nsw-row" style={{ paddingTop: '30px' }}>
-              <div className="nsw-col" style={{ padding: 'inherit', width: '80%' }}>
-                <Button
-                  as="dark"
-                  onClick={(e) => {
-                    setFlow('forward');
-                    setStepNumber(stepNumber + 1);
-                    updateEstimatorFormAnalytics({
-                      sf_postcode: postcode,
-                    });
-                  }}
-                  style={{ float: 'right' }}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
-          )}
         </Fragment>
       </div>
       {stepNumber === 2 && (
@@ -300,14 +280,10 @@ export default function CertificateEstimatorRefrigerators(props) {
                   marginBottom: '5%',
                 }}
               >
-                <MoreOptionsCard
-                  options={[
-                    {
-                      title: 'Review eligibility for this activity',
-                      link: '/#residential-refrigeration-activity-requirements',
-                    },
-                  ]}
-                />
+                <MoreOptionsCard options={[{
+                  title: 'Review eligibility for this activity',
+                  link: '/#residential-refrigeration-activity-requirements'
+                }]}/>
               </div>
             </div>
           )}

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
@@ -478,6 +478,7 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D18_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesD18(props) {
   const {
@@ -134,7 +135,7 @@ export default function CertificateEstimatorLoadClausesD18(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D18_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D18_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -181,15 +182,12 @@ export default function CertificateEstimatorLoadClausesD18(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -250,15 +248,12 @@ export default function CertificateEstimatorLoadClausesD18(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Postcode: </b> {postcode}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Brand: </b> {selectedBrand}
                 </p>
                 <p>
-                  {' '}
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
@@ -137,6 +137,7 @@ export default function CertificateEstimatorLoadClausesD18(props) {
         if (formItem.name === 'D18_ESSJun24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -179,6 +180,10 @@ export default function CertificateEstimatorLoadClausesD18(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -244,6 +249,10 @@ export default function CertificateEstimatorLoadClausesD18(props) {
             <div class="nsw-global-alert__wrapper">
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
+                <p>
+                  {' '}
+                  <b>Postcode: </b> {postcode}{' '}
+                </p>
                 <p>
                   {' '}
                   <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
@@ -478,6 +478,7 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D20_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 
 export default function CertificateEstimatorLoadClausesD20(props) {
@@ -133,7 +134,7 @@ export default function CertificateEstimatorLoadClausesD20(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D20_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D20_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
           formItem.hide = true;
@@ -180,15 +181,12 @@ export default function CertificateEstimatorLoadClausesD20(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -249,15 +247,12 @@ export default function CertificateEstimatorLoadClausesD20(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Postcode: </b> {postcode}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Brand: </b> {selectedBrand}
                 </p>
                 <p>
-                  {' '}
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
@@ -136,6 +136,7 @@ export default function CertificateEstimatorLoadClausesD20(props) {
         if (formItem.name === 'D20_ESSJun24_PDRS__postcode') {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -178,6 +179,10 @@ export default function CertificateEstimatorLoadClausesD20(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}
@@ -243,6 +248,10 @@ export default function CertificateEstimatorLoadClausesD20(props) {
             <div class="nsw-global-alert__wrapper">
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
+                <p>
+                  {' '}
+                  <b>Postcode: </b> {postcode}{' '}
+                </p>
                 <p>
                   {' '}
                   <b>Brand: </b> {selectedBrand}{' '}

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -5,6 +5,17 @@ export const BESS1_PDRSAug24_PDRS__postcode = 'BESS1_PDRSAug24_PDRS__postcode';
 export const BESS2_PDRSAug24_PDRS__postcode = 'BESS2_PDRSAug24_PDRS__postcode';
 export const C1_PDRSAug24_PDRS__postcode = 'C1_PDRSAug24_PDRS__postcode';
 export const F7_PDRSAug24_PDRS__postcode = 'F7_PDRSAug24_PDRS__postcode';
+export const RF2_F1_2_ESSJun24_PDRS__postcode = 'RF2_F1_2_ESSJun24_PDRS__postcode';
+export const HVAC2_PDRSAug24_PDRS__postcode = 'HVAC2_PDRSAug24_PDRS__postcode';
+export const D17_ESSJun24_PDRS__postcode = 'D17_ESSJun24_PDRS__postcode';
+export const D19_ESSJun24_PDRS__postcode = 'D19_ESSJun24_PDRS__postcode';
+export const F16_electric_PDRSDec24_PDRS__postcode = 'F16_electric_PDRSDec24_PDRS__postcode';
+export const F16_gas_PDRS__postcode = 'F16_gas_PDRS__postcode';
+export const F17_ESS__postcode = 'F17_ESS__postcode';
+export const SYS2_PDRSAug24_PDRS__postcode = 'SYS2_PDRSAug24_PDRS__postcode';
+export const HVAC1_PDRSAug24_PDRS__postcode = 'HVAC1_PDRSAug24_PDRS__postcode';
+export const D18_ESSJun24_PDRS__postcode = 'D18_ESSJun24_PDRS__postcode';
+export const D20_ESSJun24_PDRS__postcode = 'D20_ESSJun24_PDRS__postcode';
 
 // Calculation
 export const BESS1_V5Nov24_PRC_calculation = 'BESS1_V5Nov24_PRC_calculation';


### PR DESCRIPTION
# [DG22-2323] Add postcode and product registry info to all steps in certificate pages

## Summary
This pull request addresses the following functionality/fixes:
* Add postcode information to step 2 and step 3 in all certificate pages.
* Add climate zone information to step 2 and step 3 in residential and commercial ac certificate page.
* Add product registry information to step 2 and step 3 for all certificate pages that need to select product registry.
* Hide postcode field in the form, since the information being display on top of page in step 2 and step 3 now. 

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2323

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None

[DG22-2323]: https://essnsw.atlassian.net/browse/DG22-2323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ