### PR TITLE
[DG22-2379] Fixing post code field still showing up at step 2 in certificates pages

### DIFF
--- a/src/components/form_elements/FormTextInput.jsx
+++ b/src/components/form_elements/FormTextInput.jsx
@@ -13,7 +13,7 @@ export default function FormTextInput(props) {
       label={formItem.metadata.label} // helper text (secondary label)
       error="Invalid value!" // error text if invalid
       status={formItem.invalid && 'invalid'} // if `true` renders invalid formatting
-      className={`${formItem.hide ? 'nsw-display-none' : ''}`}
+      style={formItem.hide ? { display: 'none' } : {}}
     >
       <TextInput
         style={{ maxWidth: '50%', marginBottom: '4%' }}


### PR DESCRIPTION
# [DG22-2379] Fixing post code field still showing up at step 2 in certificates pages

## Summary
This pull request addresses the following functionality/fixes:
* Use display none inline style instead of using class nsw-display-none

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2379

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None

[DG22-2379]: https://essnsw.atlassian.net/browse/DG22-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ