### PR TITLE
[DG22-2379] Fixing post code field still showing up at step 2 in certificates

### DIFF
--- a/src/components/calculate/CalculateBlock.js
+++ b/src/components/calculate/CalculateBlock.js
@@ -57,6 +57,7 @@ export default function CalculateBlock(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    setPostcode,
   } = props;
 
   useEffect(() => {
@@ -701,6 +702,7 @@ export default function CalculateBlock(props) {
       setCalculationError2={setCalculationError2}
       stepNumber={stepNumber}
       setStepNumber={setStepNumber}
+      setPostcode={setPostcode}
       dependencies={dependencies}
       workflow={workflow}
       selectedBrand={selectedBrand}

--- a/src/components/calculate/CalculateForm.js
+++ b/src/components/calculate/CalculateForm.js
@@ -70,6 +70,7 @@ export default function CalculateForm(props) {
     showError,
     setShowError,
     postcode,
+    setPostcode,
     annualEnergySavings,
     peakDemandReductionSavings,
     annualEnergySavingsNumber,
@@ -367,6 +368,7 @@ export default function CalculateForm(props) {
                     setShowPostcodeError(false);
                     setFlow(null);
                     setStepNumber(stepNumber + 1);
+                    setPostcode(variable.form_value);
                     updatePostCodeAnalytics(variable.form_value);
                     submitEstimatorFormAnalytics();
                   } else {

--- a/src/components/certificate-price/CertificiatePrice.js
+++ b/src/components/certificate-price/CertificiatePrice.js
@@ -10,30 +10,26 @@ export default function CertificiatePrice(props) {
     prcMaxPrice = 0
   } = props;
 
-  const esc_calculation_min_price = (escCertificates * escMinPrice).toFixed(2)
-  const esc_calculation_max_price = (escCertificates * escMaxPrice).toFixed(2)
-  const prc_calculation_min_price = (prcCertificates * prcMinPrice).toFixed(2)
-  const prc_calculation_max_price = (prcCertificates * prcMaxPrice).toFixed(2)
+  const esc_calculation_min_price = Math.floor(escCertificates * escMinPrice)
+  const esc_calculation_max_price = Math.floor(escCertificates * escMaxPrice)
+  const prc_calculation_min_price = Math.floor(prcCertificates * prcMinPrice)
+  const prc_calculation_max_price = Math.floor(prcCertificates * prcMaxPrice)
 
   return (
     <>
       {(escCertificates > 0 || prcCertificates > 0) && (
-        <div>
-          <h4 className="nsw-m-bottom-lg">DRAFT HEADING How much is the incentive?</h4>
+        <div className="nsw-m-bottom-xxl">
+          <h4 style={{marginBottom: '1.25rem'}}>How much is the incentive?</h4>
           <p>
-            DRAFT ONLY Please note that certificate prices can changes daily and this estimate is a
-            guide only. Incentives are calculated by the number of certificates multiplied by the
-            certificate price, then minus administration costs.
-          </p>
-          <p>
-            The actual incentive will vary according to fluctuating certificate prices and
-            administration costs such as:
+            Certificate prices can change daily and this estimate is a
+            guide only. The incentive's will vary due to a number of factors, including:
           </p>
           <ul className="nsw-m-bottom-xl">
+            <li className="nsw-m-top-0">changing certificate prices</li>
+            <li className="nsw-m-top-0">business administration costs</li>
             <li className="nsw-m-top-0">travel and transportation costs</li>
-            <li className="nsw-m-top-0">the model you choose to install</li>
-            <li className="nsw-m-top-0">the complexity of installation and the need for any additional building work
-            </li>
+            <li className="nsw-m-top-0">the model you install</li>
+            <li className="nsw-m-top-0">the complexity of the installation and the need for any extra building work</li>
           </ul>
 
           {escCertificates > 0 && (
@@ -41,9 +37,7 @@ export default function CertificiatePrice(props) {
               <div className="nsw-layout">
                 <div className="nsw-layout__sidebar nsw-layout__sidebar--desktop">
                   <div className="nsw-docs__box nsw-docs__box--large">
-                <span style={{ display: 'block', marginTop: '1rem' }}>
-                  <b>ESCs Certificates {escCertificates}</b>
-                </span>
+                    <h4 style={{marginTop: '1.5rem'}}>ESCs Certificates {escCertificates}</h4>
                   </div>
                 </div>
                 <main className="nsw-layout__main">
@@ -54,7 +48,7 @@ export default function CertificiatePrice(props) {
                       style={{ marginTop: 0 }}
                     >
                       <p>
-                        * Actual incentive amount will vary depending on certificate pricing and
+                        *Actual incentive amount will vary depending on certificate pricing and
                         administrative fees
                       </p>
                     </Alert>
@@ -69,9 +63,7 @@ export default function CertificiatePrice(props) {
               <div className="nsw-layout">
                 <div className="nsw-layout__sidebar nsw-layout__sidebar--desktop">
                   <div className="nsw-docs__box nsw-docs__box--large">
-                <span style={{ display: 'block', marginTop: '1rem' }}>
-                  <b>PRCs Certificates {prcCertificates}</b>
-                </span>
+                    <h4 style={{marginTop: '1.5rem'}}>PRCs Certificates {prcCertificates}</h4>
                   </div>
                 </div>
                 <main className="nsw-layout__main">
@@ -82,7 +74,7 @@ export default function CertificiatePrice(props) {
                       style={{ marginTop: 0 }}
                     >
                       <p>
-                        * Actual incentive amount will vary depending on certificate pricing and
+                        *Actual incentive amount will vary depending on certificate pricing and
                         administrative fees
                       </p>
                     </Alert>

--- a/src/components/certificate-price/CertificiatePrice.js
+++ b/src/components/certificate-price/CertificiatePrice.js
@@ -22,7 +22,7 @@ export default function CertificiatePrice(props) {
           <h4 style={{marginBottom: '1.25rem'}}>How much is the incentive?</h4>
           <p>
             Certificate prices can change daily and this estimate is a
-            guide only. The incentive's will vary due to a number of factors, including:
+            guide only. The incentive will vary due to a number of factors, including:
           </p>
           <ul className="nsw-m-bottom-xl">
             <li className="nsw-m-top-0">changing certificate prices</li>
@@ -33,54 +33,32 @@ export default function CertificiatePrice(props) {
           </ul>
 
           {escCertificates > 0 && (
-            <div className="nsw-container nsw-m-bottom-md" style={{ paddingLeft: 0, paddingRight: 0 }}>
-              <div className="nsw-layout">
-                <div className="nsw-layout__sidebar nsw-layout__sidebar--desktop">
-                  <div className="nsw-docs__box nsw-docs__box--large">
-                    <h4 style={{marginTop: '1.5rem'}}>ESCs Certificates {escCertificates}</h4>
-                  </div>
-                </div>
-                <main className="nsw-layout__main">
-                  <div className="nsw-docs__box nsw-docs__box--large">
-                    <Alert
-                      as="info"
-                      title={`Potential ESCs Incentives $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
-                      style={{ marginTop: 0 }}
-                    >
-                      <p>
-                        *Actual incentive amount will vary depending on certificate pricing and
-                        administrative fees
-                      </p>
-                    </Alert>
-                  </div>
-                </main>
-              </div>
+            <div className={ prcCertificates > 0 ? `nsw-container nsw-m-bottom-lg` : ''} style={{ paddingLeft: 0, paddingRight: 0 }}>
+              <Alert
+                as="info"
+                title={`Potential ESCs Incentives $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
+                style={{ marginTop: 0 }}
+              >
+                <p>
+                  *Actual incentive amount will vary depending on certificate pricing and
+                  administrative fees
+                </p>
+              </Alert>
             </div>
           )}
 
           {prcCertificates > 0 && (
             <div className="nsw-container" style={{ paddingLeft: 0, paddingRight: 0 }}>
-              <div className="nsw-layout">
-                <div className="nsw-layout__sidebar nsw-layout__sidebar--desktop">
-                  <div className="nsw-docs__box nsw-docs__box--large">
-                    <h4 style={{marginTop: '1.5rem'}}>PRCs Certificates {prcCertificates}</h4>
-                  </div>
-                </div>
-                <main className="nsw-layout__main">
-                  <div className="nsw-docs__box nsw-docs__box--large">
-                    <Alert
-                      as="info"
-                      title={`Potential PRCs Incentives $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
-                      style={{ marginTop: 0 }}
-                    >
-                      <p>
-                        *Actual incentive amount will vary depending on certificate pricing and
-                        administrative fees
-                      </p>
-                    </Alert>
-                  </div>
-                </main>
-              </div>
+              <Alert
+                as="info"
+                title={`Potential PRCs Incentives $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
+                style={{ marginTop: 0 }}
+              >
+                <p>
+                  *Actual incentive amount will vary depending on certificate pricing and
+                  administrative fees
+                </p>
+              </Alert>
             </div>
           )}
         </div>

--- a/src/components/certificate-price/CertificiatePrice.js
+++ b/src/components/certificate-price/CertificiatePrice.js
@@ -10,10 +10,10 @@ export default function CertificiatePrice(props) {
     prcMaxPrice = 0
   } = props;
 
-  const esc_calculation_min_price = Math.floor(escCertificates * escMinPrice)
-  const esc_calculation_max_price = Math.floor(escCertificates * escMaxPrice)
-  const prc_calculation_min_price = Math.floor(prcCertificates * prcMinPrice)
-  const prc_calculation_max_price = Math.floor(prcCertificates * prcMaxPrice)
+  const esc_calculation_min_price = Math.floor(Math.floor(escCertificates) * escMinPrice)
+  const esc_calculation_max_price = Math.floor(Math.floor(escCertificates) * escMaxPrice)
+  const prc_calculation_min_price = Math.floor(Math.floor(prcCertificates) * prcMinPrice)
+  const prc_calculation_max_price = Math.floor(Math.floor(prcCertificates) * prcMaxPrice)
 
   return (
     <>
@@ -36,7 +36,7 @@ export default function CertificiatePrice(props) {
             <div className={ prcCertificates > 0 ? `nsw-container nsw-m-bottom-lg` : ''} style={{ paddingLeft: 0, paddingRight: 0 }}>
               <Alert
                 as="info"
-                title={`Potential ESCs Incentives $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
+                title={`Potential ESCs incentive $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
                 style={{ marginTop: 0 }}
               >
                 <p>
@@ -51,7 +51,7 @@ export default function CertificiatePrice(props) {
             <div className="nsw-container" style={{ paddingLeft: 0, paddingRight: 0 }}>
               <Alert
                 as="info"
-                title={`Potential PRCs Incentives $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
+                title={`Potential PRCs incentive $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
                 style={{ marginTop: 0 }}
               >
                 <p>

--- a/src/components/certificate-price/CertificiatePrice.js
+++ b/src/components/certificate-price/CertificiatePrice.js
@@ -1,4 +1,5 @@
 import Alert from 'nsw-ds-react/alert/alert';
+import { formatNumber} from 'lib/helper';
 
 export default function CertificiatePrice(props) {
   const {
@@ -36,7 +37,7 @@ export default function CertificiatePrice(props) {
             <div className={ prcCertificates > 0 ? `nsw-container nsw-m-bottom-lg` : ''} style={{ paddingLeft: 0, paddingRight: 0 }}>
               <Alert
                 as="info"
-                title={`Potential ESCs incentive $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
+                title={`Potential ESCs incentive $${formatNumber(esc_calculation_min_price)} - $${formatNumber(esc_calculation_max_price)}*`}
                 style={{ marginTop: 0 }}
               >
                 <p>
@@ -51,7 +52,7 @@ export default function CertificiatePrice(props) {
             <div className="nsw-container" style={{ paddingLeft: 0, paddingRight: 0 }}>
               <Alert
                 as="info"
-                title={`Potential PRCs incentive $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
+                title={`Potential PRCs incentive $${formatNumber(prc_calculation_min_price)} - $${formatNumber(prc_calculation_max_price)}*`}
                 style={{ marginTop: 0 }}
               >
                 <p>

--- a/src/components/certificate-price/CertificiatePrice.js
+++ b/src/components/certificate-price/CertificiatePrice.js
@@ -1,0 +1,98 @@
+import Alert from 'nsw-ds-react/alert/alert';
+
+export default function CertificiatePrice(props) {
+  const {
+    escCertificates = 0,
+    prcCertificates = 0,
+    escMinPrice = 0,
+    escMaxPrice = 0,
+    prcMinPrice = 0,
+    prcMaxPrice = 0
+  } = props;
+
+  const esc_calculation_min_price = (escCertificates * escMinPrice).toFixed(2)
+  const esc_calculation_max_price = (escCertificates * escMaxPrice).toFixed(2)
+  const prc_calculation_min_price = (prcCertificates * prcMinPrice).toFixed(2)
+  const prc_calculation_max_price = (prcCertificates * prcMaxPrice).toFixed(2)
+
+  return (
+    <>
+      {(escCertificates > 0 || prcCertificates > 0) && (
+        <div>
+          <h4 className="nsw-m-bottom-lg">DRAFT HEADING How much is the incentive?</h4>
+          <p>
+            DRAFT ONLY Please note that certificate prices can changes daily and this estimate is a
+            guide only. Incentives are calculated by the number of certificates multiplied by the
+            certificate price, then minus administration costs.
+          </p>
+          <p>
+            The actual incentive will vary according to fluctuating certificate prices and
+            administration costs such as:
+          </p>
+          <ul className="nsw-m-bottom-xl">
+            <li className="nsw-m-top-0">travel and transportation costs</li>
+            <li className="nsw-m-top-0">the model you choose to install</li>
+            <li className="nsw-m-top-0">the complexity of installation and the need for any additional building work
+            </li>
+          </ul>
+
+          {escCertificates > 0 && (
+            <div className="nsw-container nsw-m-bottom-md" style={{ paddingLeft: 0, paddingRight: 0 }}>
+              <div className="nsw-layout">
+                <div className="nsw-layout__sidebar nsw-layout__sidebar--desktop">
+                  <div className="nsw-docs__box nsw-docs__box--large">
+                <span style={{ display: 'block', marginTop: '1rem' }}>
+                  <b>ESCs Certificates {escCertificates}</b>
+                </span>
+                  </div>
+                </div>
+                <main className="nsw-layout__main">
+                  <div className="nsw-docs__box nsw-docs__box--large">
+                    <Alert
+                      as="info"
+                      title={`Potential ESCs Incentives $${esc_calculation_min_price} - $${esc_calculation_max_price}*`}
+                      style={{ marginTop: 0 }}
+                    >
+                      <p>
+                        * Actual incentive amount will vary depending on certificate pricing and
+                        administrative fees
+                      </p>
+                    </Alert>
+                  </div>
+                </main>
+              </div>
+            </div>
+          )}
+
+          {prcCertificates > 0 && (
+            <div className="nsw-container" style={{ paddingLeft: 0, paddingRight: 0 }}>
+              <div className="nsw-layout">
+                <div className="nsw-layout__sidebar nsw-layout__sidebar--desktop">
+                  <div className="nsw-docs__box nsw-docs__box--large">
+                <span style={{ display: 'block', marginTop: '1rem' }}>
+                  <b>PRCs Certificates {prcCertificates}</b>
+                </span>
+                  </div>
+                </div>
+                <main className="nsw-layout__main">
+                  <div className="nsw-docs__box nsw-docs__box--large">
+                    <Alert
+                      as="info"
+                      title={`Potential PRCs Incentives $${prc_calculation_min_price} - $${prc_calculation_max_price}*`}
+                      style={{ marginTop: 0 }}
+                    >
+                      <p>
+                        * Actual incentive amount will vary depending on certificate pricing and
+                        administrative fees
+                      </p>
+                    </Alert>
+                  </div>
+                </main>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/form_elements/FormTextInput.jsx
+++ b/src/components/form_elements/FormTextInput.jsx
@@ -13,7 +13,7 @@ export default function FormTextInput(props) {
       label={formItem.metadata.label} // helper text (secondary label)
       error="Invalid value!" // error text if invalid
       status={formItem.invalid && 'invalid'} // if `true` renders invalid formatting
-      className={`${formItem.hide ? 'nsw-display-none' : ''}`}
+      style={formItem.hide ? { display: 'none' } : {}}
     >
       <TextInput
         style={{ maxWidth: '50%', marginBottom: '4%' }}

--- a/src/components/form_elements/FormTextInput.jsx
+++ b/src/components/form_elements/FormTextInput.jsx
@@ -13,6 +13,7 @@ export default function FormTextInput(props) {
       label={formItem.metadata.label} // helper text (secondary label)
       error="Invalid value!" // error text if invalid
       status={formItem.invalid && 'invalid'} // if `true` renders invalid formatting
+      className={`${formItem.hide ? 'nsw-display-none' : ''}`}
     >
       <TextInput
         style={{ maxWidth: '50%', marginBottom: '4%' }}

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -1,0 +1,12 @@
+
+/**
+ * Format a number with commas for readability, and two decimal places.
+ *
+ * @param {number} num
+ * @return {string}
+ */
+function formatNumber(num) {
+  return num.toLocaleString('en-AU', {maximumFractionDigits:2});
+}
+
+export { formatNumber };

--- a/src/pages/BESS1/ActivityRequirementsBESS1.jsx
+++ b/src/pages/BESS1/ActivityRequirementsBESS1.jsx
@@ -141,7 +141,7 @@ export default function ActivityRequirementsBESS1(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/BESS1/ActivityRequirementsBESS1.jsx
+++ b/src/pages/BESS1/ActivityRequirementsBESS1.jsx
@@ -23,11 +23,11 @@ import {
   updateEstimatorFormAnalytics,
   updateFeedbackFormAnalytics,
   updateSegmentCaptureAnalytics,
-  clearSearchCaptureAnalytics,
+  clearSearchCaptureAnalytics
 } from 'lib/analytics';
 import FeedbackComponent from 'components/feedback/feedback';
 import MoreOptionsCard from 'components/more-options-card/more-options-card';
-import { BASE_BESS1_ELIGIBILITY_ANALYTICS_DATA } from 'constant/base-analytics-data';
+import {BASE_BESS1_ELIGIBILITY_ANALYTICS_DATA} from 'constant/base-analytics-data';
 
 export default function ActivityRequirementsBESS1(props) {
   const { entities, variables, loading, setLoading } = props;
@@ -141,7 +141,7 @@ export default function ActivityRequirementsBESS1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -196,7 +196,7 @@ export default function ActivityRequirementsBESS1(props) {
                   label="What is your interest in the scheme?"
                   helper="Select the option that best describes you"
                   htmlId="user-type"
-                  style={{ marginTop: '4%' }}
+                  style={{marginTop: '4%'}}
                 >
                   <Select
                     htmlId="user-type"

--- a/src/pages/BESS1/CertificateEstimatorBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorBESS1.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesBESS1 from './CertificateEstimatorLoadClausesBESS1';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -42,6 +43,8 @@ export default function CertificateEstimatorBESS1(props) {
   const [selectedModel, setSelectedModel] = useState(null);
   const [postcode, setPostcode] = useState(null);
   const [userType, setUserType] = useState('');
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -91,6 +94,20 @@ export default function CertificateEstimatorBESS1(props) {
         console.log(err);
       });
   }, [variables, entities]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setPrcMinPrice(Number(response.data.ESC.min_price))
+        setPrcMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -201,6 +218,8 @@ export default function CertificateEstimatorBESS1(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -237,6 +256,8 @@ export default function CertificateEstimatorBESS1(props) {
               setShowError={setShowError}
               userType={userType}
               setUserType={setUserType}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
         </Fragment>

--- a/src/pages/BESS1/CertificateEstimatorBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorBESS1.jsx
@@ -99,8 +99,8 @@ export default function CertificateEstimatorBESS1(props) {
     const fetchCertificatePrice = async function () {
       try {
         const response = await RegistryApi.getCertificatePrice()
-        setPrcMinPrice(Number(response.data.ESC.min_price))
-        setPrcMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
       } catch (e) {
         console.log(e)
       }

--- a/src/pages/BESS1/CertificateEstimatorBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorBESS1.jsx
@@ -126,7 +126,7 @@ export default function CertificateEstimatorBESS1(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -164,7 +164,7 @@ export default function CertificateEstimatorBESS1(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 2 && loading && !showError && <SpinnerFullscreen />}
 

--- a/src/pages/BESS1/CertificateEstimatorBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorBESS1.jsx
@@ -207,6 +207,7 @@ export default function CertificateEstimatorBESS1(props) {
               selectedBrand={selectedBrand}
               selectedModel={selectedModel}
               postcode={postcode}
+              setPostcode={setPostcode}
               flow={flow}
               setFlow={setFlow}
               loading={loading}
@@ -244,6 +245,7 @@ export default function CertificateEstimatorBESS1(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
@@ -33,6 +33,7 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
     selectedBrand,
     selectedModel,
     postcode,
+    setPostcode,
     flow,
     setFlow,
     persistFormValues,
@@ -168,6 +169,7 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -196,6 +198,19 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    <b>Postcode: </b> {postcode}
+                  </p>
+                </div>
+              </div>
+            </div>
             {
               <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
@@ -11,6 +11,7 @@ import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesBESS1(props) {
   const {
@@ -50,6 +51,8 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -194,7 +197,7 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -244,11 +247,15 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginBottom: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
+++ b/src/pages/BESS1/CertificateEstimatorLoadClausesBESS1.jsx
@@ -12,6 +12,7 @@ import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesBESS1(props) {
   const {
@@ -216,20 +217,16 @@ export default function CertificateEstimatorLoadClausesBESS1(props) {
                 <p>
                   Based on the information provided, your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual contribution to reducing peak summer energy demand is{' '}
                   <b>
-                    <b>
-                      {' '}
-                      {Math.floor(calculationResult) === 0
-                        ? 0
-                        : Math.round(peakDemandReductionSavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult) === 0
+                      ? 0
+                      : formatNumber(Math.round(peakDemandReductionSavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   As this activity is only eligible for the Peak Demand Reduction Scheme, it

--- a/src/pages/BESS2/ActivityRequirementsBESS2.jsx
+++ b/src/pages/BESS2/ActivityRequirementsBESS2.jsx
@@ -138,7 +138,7 @@ export default function ActivityRequirementsBESS2(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/BESS2/ActivityRequirementsBESS2.jsx
+++ b/src/pages/BESS2/ActivityRequirementsBESS2.jsx
@@ -138,7 +138,7 @@ export default function ActivityRequirementsBESS2(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/BESS2/CertificateEstimatorBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorBESS2.jsx
@@ -99,8 +99,8 @@ export default function CertificateEstimatorBESS2(props) {
     const fetchCertificatePrice = async function () {
       try {
         const response = await RegistryApi.getCertificatePrice()
-        setPrcMinPrice(Number(response.data.ESC.min_price))
-        setPrcMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
       } catch (e) {
         console.log(e)
       }

--- a/src/pages/BESS2/CertificateEstimatorBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorBESS2.jsx
@@ -126,7 +126,7 @@ export default function CertificateEstimatorBESS2(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -164,7 +164,7 @@ export default function CertificateEstimatorBESS2(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 2 && loading && !showError && <SpinnerFullscreen />}
 

--- a/src/pages/BESS2/CertificateEstimatorBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorBESS2.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesBESS2 from './CertificateEstimatorLoadClausesBESS2';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -42,6 +43,8 @@ export default function CertificateEstimatorBESS2(props) {
   const [selectedModel, setSelectedModel] = useState(null);
   const [postcode, setPostcode] = useState(null);
   const [userType, setUserType] = useState('');
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -91,6 +94,20 @@ export default function CertificateEstimatorBESS2(props) {
         console.log(err);
       });
   }, [variables, entities]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setPrcMinPrice(Number(response.data.ESC.min_price))
+        setPrcMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -201,6 +218,8 @@ export default function CertificateEstimatorBESS2(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -237,6 +256,8 @@ export default function CertificateEstimatorBESS2(props) {
               setShowError={setShowError}
               userType={userType}
               setUserType={setUserType}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
         </Fragment>

--- a/src/pages/BESS2/CertificateEstimatorBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorBESS2.jsx
@@ -207,6 +207,7 @@ export default function CertificateEstimatorBESS2(props) {
               selectedBrand={selectedBrand}
               selectedModel={selectedModel}
               postcode={postcode}
+              setPostcode={setPostcode}
               flow={flow}
               setFlow={setFlow}
               loading={loading}
@@ -244,6 +245,7 @@ export default function CertificateEstimatorBESS2(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
@@ -12,6 +12,7 @@ import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesBESS2(props) {
   const {
@@ -216,20 +217,16 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
                 <p>
                   Based on the information provided, your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual contribution to reducing peak summer energy demand is{' '}
                   <b>
-                    <b>
-                      {' '}
-                      {Math.floor(calculationResult) === 0
-                        ? 0
-                        : Math.round(peakDemandReductionSavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult) === 0
+                      ? 0
+                      : formatNumber(Math.round(peakDemandReductionSavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   As this activity is only eligible for the Peak Demand Reduction Scheme, it

--- a/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
@@ -11,6 +11,7 @@ import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesBESS2(props) {
   const {
@@ -50,6 +51,8 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -194,7 +197,7 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -244,11 +247,15 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginBottom: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
+++ b/src/pages/BESS2/CertificateEstimatorLoadClausesBESS2.jsx
@@ -33,6 +33,7 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
     selectedBrand,
     selectedModel,
     postcode,
+    setPostcode,
     flow,
     setFlow,
     persistFormValues,
@@ -168,6 +169,7 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -196,6 +198,19 @@ export default function CertificateEstimatorLoadClausesBESS2(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    <b>Postcode: </b> {postcode}
+                  </p>
+                </div>
+              </div>
+            </div>
             {
               <Alert as="info" title="PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/base_eligibility/BaseEligibility.jsx
+++ b/src/pages/base_eligibility/BaseEligibility.jsx
@@ -137,7 +137,7 @@ export default function BaseEligibility(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/base_eligibility/BaseEligibility.jsx
+++ b/src/pages/base_eligibility/BaseEligibility.jsx
@@ -137,7 +137,7 @@ export default function BaseEligibility(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/base_eligibility/BaseEligibility.jsx
+++ b/src/pages/base_eligibility/BaseEligibility.jsx
@@ -175,7 +175,7 @@ export default function BaseEligibility(props) {
           </div>
         )}
 
-        {stepNumber === 2 && (
+        {!IS_DRUPAL_PAGES && stepNumber === 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-10">
               <h2 className="nsw-content-block__title">Core eligibility requirements</h2>

--- a/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
+++ b/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
@@ -170,7 +170,7 @@ export default function ActivityRequirementsCommercialAC(props) {
           </div>
         )}
 
-        {stepNumber === 2 && (
+        {!IS_DRUPAL_PAGES && stepNumber === 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-12">
               <h2 className="nsw-content-block__title">

--- a/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
+++ b/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsCommercialAC(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
+++ b/src/pages/commercial_ac/ActivityRequirementsAirCon.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsCommercialAC(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClauses(props) {
   const {
@@ -47,6 +48,10 @@ export default function CertificateEstimatorLoadClauses(props) {
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
     selectedClimateZone,
+    escMinPrice,
+    escMaxPrice,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   const bca_mapping = {
@@ -284,7 +289,7 @@ export default function CertificateEstimatorLoadClauses(props) {
               </div>
             </div>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -345,11 +350,18 @@ export default function CertificateEstimatorLoadClauses(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -9,7 +9,10 @@ import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
-
+import {
+  HVAC2_PDRSAug24_PDRS__postcode,
+  HVAC2_PDRSAug24_BCA_Climate_Zone
+} from 'types/openfisca_variables';
 export default function CertificateEstimatorLoadClauses(props) {
   const {
     variableToLoad1,
@@ -171,13 +174,15 @@ export default function CertificateEstimatorLoadClauses(props) {
         ) {
           formItem.form_value = metadata['Rated ACOP'];
         }
-        if (formItem.name === 'HVAC2_PDRSAug24_PDRS__postcode') {
+        if (formItem.name === HVAC2_PDRSAug24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
-        if (formItem.name === 'HVAC2_PDRSAug24_BCA_Climate_Zone') {
+        if (formItem.name === HVAC2_PDRSAug24_BCA_Climate_Zone) {
           formItem.form_value = bca_mapping[selectedClimateZone];
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -212,11 +217,15 @@ export default function CertificateEstimatorLoadClauses(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>BCA Climate Zone: </b> {selectedClimateZone.charAt(selectedClimateZone.length - 1)}
+                  </p>
+                  <p>
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -277,6 +286,15 @@ export default function CertificateEstimatorLoadClauses(props) {
               <div class="nsw-global-alert__wrapper">
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
+                  <p>
+                    {' '}
+                    <b>Postcode: </b> {postcode}{' '}
+                  </p>
+                  <p>
+                    {' '}
+                    <b>BCA Climate Zone: </b>{' '}
+                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                  </p>
                   <p>
                     {' '}
                     <b>Brand: </b> {selectedBrand}{' '}

--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -13,6 +13,8 @@ import {
   HVAC2_PDRSAug24_PDRS__postcode,
   HVAC2_PDRSAug24_BCA_Climate_Zone
 } from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
+
 export default function CertificateEstimatorLoadClauses(props) {
   const {
     variableToLoad1,
@@ -287,20 +289,15 @@ export default function CertificateEstimatorLoadClauses(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Postcode: </b> {postcode}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
-                    <b>BCA Climate Zone: </b>{' '}
-                    {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
+                    <b>BCA Climate Zone: </b> {selectedClimateZone.charAt(selectedClimateZone.length - 1)}{' '}
                   </p>
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Brand: </b> {selectedBrand}
                   </p>
                   <p>
-                    {' '}
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -312,37 +309,31 @@ export default function CertificateEstimatorLoadClauses(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                   {/* </h4> */}
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   and your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult))}</b>
                   </span>
                   {/* </h4> */}
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult) === 0
-                        ? 0
-                        : Math.round(peakDemandReductionSavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult) === 0
+                      ? 0
+                      : formatNumber(Math.round(peakDemandReductionSavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -54,6 +54,10 @@ export default function CertificateEstimatorHVAC(props) {
   const [selectedClimateZone, setSelectedClimateZone] = useState('');
   const [dropdownOptionsClimateZone, setDropdownOptionsClimateZone] = useState([]);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -104,6 +108,22 @@ export default function CertificateEstimatorHVAC(props) {
       setPeakDemandReductionSavingsNumber(0);
     }
   }, [peakDemandReductionSavingsNumber]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   // For brands
   const populateDropDown = (newOption) => {
@@ -550,6 +570,10 @@ export default function CertificateEstimatorHVAC(props) {
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               selectedClimateZone={selectedClimateZone}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -588,6 +612,10 @@ export default function CertificateEstimatorHVAC(props) {
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               selectedClimateZone={selectedClimateZone}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -594,6 +594,7 @@ export default function CertificateEstimatorHVAC(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -335,7 +335,7 @@ export default function CertificateEstimatorHVAC(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -396,7 +396,7 @@ export default function CertificateEstimatorHVAC(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -644,7 +644,7 @@ export default function CertificateEstimatorHVAC(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -156,6 +156,7 @@ export default function CertificateEstimatorHVAC(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -91,19 +91,6 @@ export default function CertificateEstimatorHVAC(props) {
           console.log(err);
         });
     }
-
-    if (hvacBrands.length < 1) {
-      RegistryApi.getCommercialHVACBrands()
-        .then((res) => {
-          setHvacBrands(res.data);
-          setLoading(false);
-          setRegistryData(true);
-        })
-        .catch((err) => {
-          console.log(err);
-          setRegistryData(false);
-        });
-    }
   }, []);
 
   useEffect(() => {

--- a/src/pages/commercial_motors/ActivityRequirementsSYS1.jsx
+++ b/src/pages/commercial_motors/ActivityRequirementsSYS1.jsx
@@ -13,11 +13,11 @@ import {
   updateEstimatorFormAnalytics,
   updateFeedbackFormAnalytics,
   updateSegmentCaptureAnalytics,
-  clearSearchCaptureAnalytics,
+  clearSearchCaptureAnalytics
 } from 'lib/analytics';
 import FeedbackComponent from 'components/feedback/feedback';
 import MoreOptionsCard from 'components/more-options-card/more-options-card';
-import { BASE_COMMERCIAL_MOTOR_ELIGIBILITY_ANALYTICS_DATA } from 'constant/base-analytics-data';
+import {BASE_COMMERCIAL_MOTOR_ELIGIBILITY_ANALYTICS_DATA} from 'constant/base-analytics-data';
 
 export default function ActivityRequirementsSYS1(props) {
   const { entities, variables, loading, setLoading } = props;
@@ -111,7 +111,7 @@ export default function ActivityRequirementsSYS1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -167,7 +167,7 @@ export default function ActivityRequirementsSYS1(props) {
                   label="What is your interest in the scheme?"
                   helper="Select the option that best describes you"
                   htmlId="user-type"
-                  style={{ marginTop: '4%' }}
+                  style={{marginTop: '4%'}}
                 >
                   <Select
                     htmlId="user-type"

--- a/src/pages/commercial_motors/ActivityRequirementsSYS1.jsx
+++ b/src/pages/commercial_motors/ActivityRequirementsSYS1.jsx
@@ -111,7 +111,7 @@ export default function ActivityRequirementsSYS1(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
@@ -10,7 +10,8 @@ import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
-import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import {updateSegmentCaptureAnalytics} from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesMotors(props) {
   const {
@@ -47,6 +48,8 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -184,7 +187,7 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -228,11 +231,15 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
@@ -12,6 +12,7 @@ import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import {updateSegmentCaptureAnalytics} from 'lib/analytics';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesMotors(props) {
   const {
@@ -208,19 +209,16 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
                 <p>
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
@@ -50,6 +50,8 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
     setUserType,
     escMinPrice,
     escMaxPrice,
+    postcode,
+    setPostcode,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -158,6 +160,7 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -186,6 +189,20 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    <b>Postcode: </b> {postcode}
+                  </p>
+                </div>
+              </div>
+            </div>
+
             {
               <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
@@ -204,6 +204,8 @@ export default function CertificateEstimatorMotors(props) {
               setCalculationError2={setCalculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
+              setPostcode={setPostcode}
               persistFormValues={persistFormValues}
               setPersistFormValues={setPersistFormValues}
               formValues={formValues}
@@ -245,6 +247,7 @@ export default function CertificateEstimatorMotors(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}
@@ -260,23 +263,6 @@ export default function CertificateEstimatorMotors(props) {
               escMinPrice={escMinPrice}
               escMaxPrice={escMaxPrice}
             />
-          )}
-
-          {stepNumber === 1 && registryData && postcode && postcode.length === 4 && (
-            <div className="nsw-row" style={{ paddingTop: '30px' }}>
-              <div className="nsw-col" style={{ padding: 'inherit', width: '80%' }}>
-                <Button
-                  as="dark"
-                  onClick={(e) => {
-                    setFlow('forward');
-                    setStepNumber(stepNumber + 1);
-                  }}
-                  style={{ float: 'right' }}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
           )}
         </Fragment>
       </div>

--- a/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
@@ -127,7 +127,7 @@ export default function CertificateEstimatorMotors(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -168,7 +168,7 @@ export default function CertificateEstimatorMotors(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 2 && loading && !showError && <SpinnerFullscreen />}
 

--- a/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorMotors.jsx
@@ -3,6 +3,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesMotors from './CertificateEstimatorLoadClausesMotors';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -42,6 +43,8 @@ export default function CertificateEstimatorMotors(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -92,6 +95,20 @@ export default function CertificateEstimatorMotors(props) {
         console.log(err);
       });
   }, [variables, entities]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -202,6 +219,8 @@ export default function CertificateEstimatorMotors(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -238,6 +257,8 @@ export default function CertificateEstimatorMotors(props) {
               setShowError={setShowError}
               userType={userType}
               setUserType={setUserType}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
@@ -132,7 +132,7 @@ export default function ActivityRequirementsWH1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh/ActivityRequirementsWaterHeater.jsx
@@ -132,7 +132,7 @@ export default function ActivityRequirementsWH1(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {F16_electric_PDRSDec24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesWH(props) {
   const {
@@ -140,9 +141,10 @@ export default function CertificateEstimatorLoadClausesWH(props) {
         // if (formItem.name === 'WH1_WH_capacity_factor') {
         //   formItem.form_value = metadata['WHCap'];
         // }
-        if (formItem.name === 'F16_electric_PDRSDec24_PDRS__postcode') {
+        if (formItem.name === F16_electric_PDRSDec24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -186,11 +188,12 @@ export default function CertificateEstimatorLoadClausesWH(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -251,11 +254,12 @@ export default function CertificateEstimatorLoadClausesWH(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
+                  <b>Brand: </b> {selectedBrand}
+                </p>
+                <p>
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {F16_electric_PDRSDec24_PDRS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesWH(props) {
   const {
@@ -275,7 +276,7 @@ export default function CertificateEstimatorLoadClausesWH(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                   {/* </h4> */}
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
@@ -284,13 +285,10 @@ export default function CertificateEstimatorLoadClausesWH(props) {
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesWH(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesWH(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -263,7 +266,7 @@ export default function CertificateEstimatorLoadClausesWH(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -309,11 +312,15 @@ export default function CertificateEstimatorLoadClausesWH(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_wh/CertificateEstimatorWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorWH.jsx
@@ -462,6 +462,7 @@ export default function CertificateEstimatorWH(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/commercial_wh/CertificateEstimatorWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorWH.jsx
@@ -53,6 +53,8 @@ export default function CertificateEstimatorWH(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -204,6 +206,20 @@ export default function CertificateEstimatorWH(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -401,6 +417,8 @@ export default function CertificateEstimatorWH(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -460,6 +478,8 @@ export default function CertificateEstimatorWH(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh/CertificateEstimatorWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorWH.jsx
@@ -117,6 +117,7 @@ export default function CertificateEstimatorWH(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/commercial_wh/CertificateEstimatorWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorWH.jsx
@@ -239,7 +239,7 @@ export default function CertificateEstimatorWH(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -278,7 +278,7 @@ export default function CertificateEstimatorWH(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -491,7 +491,7 @@ export default function CertificateEstimatorWH(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/commercial_wh_F16_gas/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh_F16_gas/ActivityRequirementsWaterHeater.jsx
@@ -125,7 +125,7 @@ export default function ActivityRequirementsF16_gas(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh_F16_gas/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh_F16_gas/ActivityRequirementsWaterHeater.jsx
@@ -125,7 +125,7 @@ export default function ActivityRequirementsF16_gas(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
@@ -468,6 +468,7 @@ export default function CertificateEstimatorF16_gas(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
@@ -232,7 +232,7 @@ export default function CertificateEstimatorF16_gas(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -284,7 +284,7 @@ export default function CertificateEstimatorF16_gas(props) {
           </div>
         )} */}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -497,7 +497,7 @@ export default function CertificateEstimatorF16_gas(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
@@ -112,6 +112,7 @@ export default function CertificateEstimatorF16_gas(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorF16_gas.jsx
@@ -48,6 +48,8 @@ export default function CertificateEstimatorF16_gas(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -197,6 +199,20 @@ export default function CertificateEstimatorF16_gas(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -407,6 +423,8 @@ export default function CertificateEstimatorF16_gas(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -466,6 +484,8 @@ export default function CertificateEstimatorF16_gas(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {F16_gas_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesF16_gas(props) {
   const {
@@ -140,9 +141,10 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
         // if (formItem.name === 'WH1_WH_capacity_factor') {
         //   formItem.form_value = metadata['WHCap'];
         // }
-        if (formItem.name === 'F16_gas_PDRS__postcode') {
+        if (formItem.name === F16_gas_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -186,11 +188,12 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -251,11 +254,12 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
+                  <b>Brand: </b> {selectedBrand}
+                </p>
+                <p>
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {F16_gas_PDRS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesF16_gas(props) {
   const {
@@ -275,19 +276,16 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesF16_gas(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -263,7 +266,7 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -306,11 +309,15 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_wh_f17/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh_f17/ActivityRequirementsWaterHeater.jsx
@@ -125,7 +125,7 @@ export default function ActivityRequirementsF17(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh_f17/ActivityRequirementsWaterHeater.jsx
+++ b/src/pages/commercial_wh_f17/ActivityRequirementsWaterHeater.jsx
@@ -125,7 +125,7 @@ export default function ActivityRequirementsF17(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
@@ -233,7 +233,7 @@ export default function CertificateEstimatorF17(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -287,7 +287,7 @@ export default function CertificateEstimatorF17(props) {
           </div>
         )} */}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -500,7 +500,7 @@ export default function CertificateEstimatorF17(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
@@ -113,6 +113,7 @@ export default function CertificateEstimatorF17(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorF17(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -198,6 +200,20 @@ export default function CertificateEstimatorF17(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -410,6 +426,8 @@ export default function CertificateEstimatorF17(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -469,6 +487,8 @@ export default function CertificateEstimatorF17(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorF17.jsx
@@ -471,6 +471,7 @@ export default function CertificateEstimatorF17(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {F17_ESS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesF17(props) {
   const {
@@ -269,19 +270,16 @@ export default function CertificateEstimatorLoadClausesF17(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesF17(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesF17(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -257,7 +260,7 @@ export default function CertificateEstimatorLoadClausesF17(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -300,11 +303,15 @@ export default function CertificateEstimatorLoadClausesF17(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {F17_ESS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesF17(props) {
   const {
@@ -134,9 +135,10 @@ export default function CertificateEstimatorLoadClausesF17(props) {
         // if (formItem.name === 'WH1_WH_capacity_factor') {
         //   formItem.form_value = metadata['WHCap'];
         // }
-        if (formItem.name === 'F17_ESS__postcode') {
+        if (formItem.name === F17_ESS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -180,11 +182,12 @@ export default function CertificateEstimatorLoadClausesF17(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -245,11 +248,12 @@ export default function CertificateEstimatorLoadClausesF17(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
+                  <b>Brand: </b> {selectedBrand}
+                </p>
+                <p>
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/electric_residential_heat_pumps/ActivityRequirementsD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/ActivityRequirementsD17.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD17(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/electric_residential_heat_pumps/ActivityRequirementsD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/ActivityRequirementsD17.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD17(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorElectricHeatPump(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -87,6 +89,20 @@ export default function CertificateEstimatorElectricHeatPump(props) {
       setShowPostcodeError(false);
     }
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   RegistryApi.getResidentialHeatPumpLastModified()
     .then((res) => {
@@ -417,6 +433,8 @@ export default function CertificateEstimatorElectricHeatPump(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -476,6 +494,8 @@ export default function CertificateEstimatorElectricHeatPump(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
@@ -235,7 +235,7 @@ export default function CertificateEstimatorElectricHeatPump(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -294,7 +294,7 @@ export default function CertificateEstimatorElectricHeatPump(props) {
           </div>
         )} */}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -507,7 +507,7 @@ export default function CertificateEstimatorElectricHeatPump(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
@@ -113,6 +113,7 @@ export default function CertificateEstimatorElectricHeatPump(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorD17.jsx
@@ -476,6 +476,7 @@ export default function CertificateEstimatorElectricHeatPump(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D17_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesD17(props) {
   const {
@@ -135,9 +136,10 @@ export default function CertificateEstimatorLoadClausesD17(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D17_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D17_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -181,11 +183,12 @@ export default function CertificateEstimatorLoadClausesD17(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -246,11 +249,12 @@ export default function CertificateEstimatorLoadClausesD17(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
+                  <b>Brand: </b> {selectedBrand}
+                </p>
+                <p>
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesD17(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesD17(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -258,7 +261,7 @@ export default function CertificateEstimatorLoadClausesD17(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -308,11 +311,15 @@ export default function CertificateEstimatorLoadClausesD17(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {D17_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesD17(props) {
   const {
@@ -270,20 +271,16 @@ export default function CertificateEstimatorLoadClausesD17(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {' '}
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates

--- a/src/pages/gas_residential_heat_pumps/ActivityRequirementsD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/ActivityRequirementsD19.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD19(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/gas_residential_heat_pumps/ActivityRequirementsD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/ActivityRequirementsD19.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD19(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
@@ -484,6 +484,7 @@ export default function CertificateEstimatorGasHeatPump(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
@@ -235,7 +235,7 @@ export default function CertificateEstimatorGasHeatPump(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -296,7 +296,7 @@ export default function CertificateEstimatorGasHeatPump(props) {
           </div>
         )} */}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -507,7 +507,7 @@ export default function CertificateEstimatorGasHeatPump(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorGasHeatPump(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -200,6 +202,20 @@ export default function CertificateEstimatorGasHeatPump(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -419,6 +435,8 @@ export default function CertificateEstimatorGasHeatPump(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -476,6 +494,8 @@ export default function CertificateEstimatorGasHeatPump(props) {
               setFlow={setFlow}
               loading={loading}
               setLoading={setLoading}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorD19.jsx
@@ -113,6 +113,7 @@ export default function CertificateEstimatorGasHeatPump(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D19_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesD19(props) {
   const {
@@ -133,9 +134,10 @@ export default function CertificateEstimatorLoadClausesD19(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D19_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D19_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -179,11 +181,12 @@ export default function CertificateEstimatorLoadClausesD19(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -244,11 +247,12 @@ export default function CertificateEstimatorLoadClausesD19(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
+                  <b>Brand: </b> {selectedBrand}
+                </p>
+                <p>
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesD19(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesD19(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -256,7 +259,7 @@ export default function CertificateEstimatorLoadClausesD19(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -306,11 +309,15 @@ export default function CertificateEstimatorLoadClausesD19(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {D19_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesD19(props) {
   const {
@@ -268,20 +269,17 @@ export default function CertificateEstimatorLoadClausesD19(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
 
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
 
                 <p>

--- a/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
+++ b/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
@@ -126,7 +126,9 @@ export default function ActivityRequirementsSYS2(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
+        <br></br>
+        <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-12">

--- a/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
+++ b/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
@@ -126,7 +126,7 @@ export default function ActivityRequirementsSYS2(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
+++ b/src/pages/pool_pumps/ActivityRequirementsSYS2.jsx
@@ -169,7 +169,7 @@ export default function ActivityRequirementsSYS2(props) {
           </div>
         )}
 
-        {stepNumber === 2 && (
+        {!IS_DRUPAL_PAGES && stepNumber === 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-12">
               <h2 className="nsw-content-block__title">

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {SYS2_PDRSAug24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesPP(props) {
   const {
@@ -159,9 +160,10 @@ export default function CertificateEstimatorLoadClausesPP(props) {
           formItem.form_value = metadata['labelled_energy_consumption'];
         }
 
-        if (formItem.name === 'SYS2_PDRSAug24_PDRS__postcode') {
+        if (formItem.name === SYS2_PDRSAug24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -196,11 +198,12 @@ export default function CertificateEstimatorLoadClausesPP(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -262,11 +265,12 @@ export default function CertificateEstimatorLoadClausesPP(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -10,6 +10,7 @@ import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {SYS2_PDRSAug24_PDRS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesPP(props) {
   const {
@@ -282,38 +283,31 @@ export default function CertificateEstimatorLoadClausesPP(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                   {/* </h4> */}
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   and your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult))}</b>
                   </span>
                   {/* </h4> */}
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}
                   <b>
-                    <b>
-                      {' '}
-                      {Math.floor(calculationResult) === 0
-                        ? 0
-                        : Math.round(peakDemandReductionSavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult) === 0
+                      ? 0
+                      : formatNumber(Math.round(peakDemandReductionSavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesPP(props) {
   const {
@@ -46,6 +47,10 @@ export default function CertificateEstimatorLoadClausesPP(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   useEffect(() => {
@@ -268,7 +273,7 @@ export default function CertificateEstimatorLoadClausesPP(props) {
               </div>
             </div>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -330,11 +335,18 @@ export default function CertificateEstimatorLoadClausesPP(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+               <CertificiatePrice
+                prcCertificates={calculationResult}
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/pool_pumps/CertificateEstimatorPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorPP.jsx
@@ -56,6 +56,10 @@ export default function CertificateEstimatorPP(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     if (annualEnergySavingsNumber < 0) {
@@ -85,6 +89,22 @@ export default function CertificateEstimatorPP(props) {
           console.log(err);
         });
     }
+  }, []);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
   }, []);
 
   // For brands
@@ -418,6 +438,10 @@ export default function CertificateEstimatorPP(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -455,6 +479,10 @@ export default function CertificateEstimatorPP(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 

--- a/src/pages/pool_pumps/CertificateEstimatorPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorPP.jsx
@@ -85,19 +85,6 @@ export default function CertificateEstimatorPP(props) {
           console.log(err);
         });
     }
-
-    if (PoolPumpBrands.length < 1) {
-      RegistryApi.getPoolPumpBrands()
-        .then((res) => {
-          setPoolPumpBrands(res.data);
-          setLoading(false);
-          setRegistryData(true);
-        })
-        .catch((err) => {
-          console.log(err);
-          setRegistryData(false);
-        });
-    }
   }, []);
 
   // For brands

--- a/src/pages/pool_pumps/CertificateEstimatorPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorPP.jsx
@@ -134,6 +134,7 @@ export default function CertificateEstimatorPP(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/pool_pumps/CertificateEstimatorPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorPP.jsx
@@ -460,6 +460,7 @@ export default function CertificateEstimatorPP(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/pool_pumps/CertificateEstimatorPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorPP.jsx
@@ -233,7 +233,7 @@ export default function CertificateEstimatorPP(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -290,7 +290,7 @@ export default function CertificateEstimatorPP(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -511,7 +511,7 @@ export default function CertificateEstimatorPP(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
+++ b/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
@@ -131,7 +131,7 @@ export default function ActivityRequirementsRF2(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
+++ b/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
@@ -131,7 +131,7 @@ export default function ActivityRequirementsRF2(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
+++ b/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
@@ -173,7 +173,7 @@ export default function ActivityRequirementsRF2(props) {
           </div>
         )}
 
-        {stepNumber === 2 && (
+        {!IS_DRUPAL_PAGES && stepNumber === 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-12">
               <h2 className="nsw-content-block__title">

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesRC(props) {
   const {
@@ -47,6 +48,10 @@ export default function CertificateEstimatorLoadClausesRC(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   useEffect(() => {
@@ -251,7 +256,7 @@ export default function CertificateEstimatorLoadClausesRC(props) {
               </div>
             </div>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -312,11 +317,18 @@ export default function CertificateEstimatorLoadClausesRC(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {RF2_F1_2_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesRC(props) {
   const {
@@ -272,37 +273,31 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                   {/* </h4> */}
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   and your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult))}</b>
                   </span>
                   {/* </h4> */}
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult) === 0
-                        ? 0
-                        : Math.round(peakDemandReductionSavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult) === 0
+                      ? 0
+                      : formatNumber(Math.round(peakDemandReductionSavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {RF2_F1_2_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesRC(props) {
   const {
@@ -130,9 +131,10 @@ export default function CertificateEstimatorLoadClausesRC(props) {
         if (formItem.name === 'RF2_F1_2_ESSJun24_total_energy_consumption') {
           formItem.form_value = metadata['total_energy_consumption'];
         }
-        if (formItem.name === 'RF2_F1_2_ESSJun24_PDRS__postcode') {
+        if (formItem.name === RF2_F1_2_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
 
         if (formItem.name === 'RF2_F1_2_ESSJun24_duty_class') {
@@ -180,11 +182,12 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -245,11 +248,12 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -122,6 +122,7 @@ export default function CertificateEstimatorLoadClausesRC(props) {
         if (formItem.name === 'RF2_F1_2_ESSJun24_product_class') {
           formItem.form_value = selectedProductClass;
           formItem.read_only = true;
+          formItem.hide = true;
         }
 
         // if (formItem.name === 'RF2_total_display_area') {
@@ -190,6 +191,9 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                   <p>
                     <b>Model: </b> {selectedModel}
                   </p>
+                  <p>
+                    <b>Product Class: </b> {selectedProductClass}
+                  </p>
                 </div>
               </div>
             </div>
@@ -255,6 +259,9 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                   </p>
                   <p>
                     <b>Model: </b> {selectedModel}
+                  </p>
+                  <p>
+                    <b>Product Class: </b> {selectedProductClass}
                   </p>
                 </div>
               </div>

--- a/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
@@ -50,6 +50,10 @@ export default function CertificateEstimatorRC(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     if (annualEnergySavingsNumber < 0) {
@@ -119,6 +123,22 @@ export default function CertificateEstimatorRC(props) {
       setShowPostcodeError(false);
     }
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   if (lastModified.length == 0) {
     RegistryApi.getRF2LastModified()
@@ -452,6 +472,10 @@ export default function CertificateEstimatorRC(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -491,6 +515,10 @@ export default function CertificateEstimatorRC(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 

--- a/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
@@ -495,6 +495,7 @@ export default function CertificateEstimatorRC(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
@@ -147,6 +147,7 @@ export default function CertificateEstimatorRC(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
@@ -98,19 +98,6 @@ export default function CertificateEstimatorRC(props) {
           console.log(err);
         });
     }
-
-    if (RF2Brands.length < 1) {
-      RegistryApi.getRF2Brands()
-        .then((res) => {
-          setRF2Brands(res.data);
-          setLoading(false);
-          setRegistryData(true);
-        })
-        .catch((err) => {
-          console.log(err);
-          setRegistryData(false);
-        });
-    }
   }, []);
 
   // For brands

--- a/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificateEstimatorRC.jsx
@@ -247,7 +247,7 @@ export default function CertificateEstimatorRC(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -307,7 +307,7 @@ export default function CertificateEstimatorRC(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -546,7 +546,7 @@ export default function CertificateEstimatorRC(props) {
             selectedModel &&
             selectedProductClass &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/residential_ac/ActivityRequirementsResAC.jsx
+++ b/src/pages/residential_ac/ActivityRequirementsResAC.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsResAC(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_ac/ActivityRequirementsResAC.jsx
+++ b/src/pages/residential_ac/ActivityRequirementsResAC.jsx
@@ -168,7 +168,7 @@ export default function ActivityRequirementsResAC(props) {
           </div>
         )}
 
-        {stepNumber === 2 && (
+        {!IS_DRUPAL_PAGES && stepNumber === 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-10">
               <h2 className="nsw-content-block__title">

--- a/src/pages/residential_ac/ActivityRequirementsResAC.jsx
+++ b/src/pages/residential_ac/ActivityRequirementsResAC.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsResAC(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
@@ -93,19 +93,6 @@ export default function CertificateEstimatorResidentialAC(props) {
           console.log(err);
         });
     }
-
-    if (hvacBrands.length < 1) {
-      RegistryApi.getCommercialHVACBrands()
-        .then((res) => {
-          setHvacBrands(res.data);
-          setLoading(false);
-          setRegistryData(true);
-        })
-        .catch((err) => {
-          console.log(err);
-          setRegistryData(false);
-        });
-    }
   }, []);
 
   const populateDropDown = (newOption) => {

--- a/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
@@ -156,6 +156,7 @@ export default function CertificateEstimatorResidentialAC(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
@@ -310,7 +310,7 @@ export default function CertificateEstimatorResidentialAC(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -363,7 +363,7 @@ export default function CertificateEstimatorResidentialAC(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -609,7 +609,7 @@ export default function CertificateEstimatorResidentialAC(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
@@ -53,6 +53,10 @@ export default function CertificateEstimatorResidentialAC(props) {
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [dropdownOptionsClimateZone, setDropdownOptionsClimateZone] = useState([]);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
+  const [prcMinPrice, setPrcMinPrice] = useState(0);
+  const [prcMaxPrice, setPrcMaxPrice] = useState(0);
 
   useEffect(() => {
     if (annualEnergySavingsNumber < 0) {
@@ -270,6 +274,23 @@ export default function CertificateEstimatorResidentialAC(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+        setPrcMinPrice(Number(response.data.PRC.min_price))
+        setPrcMaxPrice(Number(response.data.PRC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -514,6 +535,10 @@ export default function CertificateEstimatorResidentialAC(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 
@@ -569,6 +594,10 @@ export default function CertificateEstimatorResidentialAC(props) {
               setAnnualEnergySavingsNumber={setAnnualEnergySavingsNumber}
               peakDemandReductionSavingsNumber={peakDemandReductionSavingsNumber}
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
+              prcMinPrice={prcMinPrice}
+              prcMaxPrice={prcMaxPrice}
             />
           )}
 

--- a/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialAC.jsx
@@ -577,6 +577,7 @@ export default function CertificateEstimatorResidentialAC(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               zone={zone}
               formValues={formValues}
               setFormValues={setFormValues}

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorResidentialACLoadClauses(props) {
   const {
@@ -47,6 +48,10 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
     selectedClimateZone,
+    escMinPrice,
+    escMaxPrice,
+    prcMinPrice,
+    prcMaxPrice
   } = props;
 
   const bca_mapping = {
@@ -356,6 +361,14 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 width: '80%',
               }}
             >
+              <CertificiatePrice
+                prcCertificates={calculationResult}
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+                prcMinPrice={prcMinPrice}
+                prcMaxPrice={prcMaxPrice}
+              />
               <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
                 <Button
                   style={{ float: 'left' }}

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -295,7 +295,7 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
               </div>
             </div>
             {
-              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs and PRCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -357,7 +357,6 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
@@ -369,7 +368,7 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 prcMinPrice={prcMinPrice}
                 prcMaxPrice={prcMaxPrice}
               />
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <div className="nsw-col-md-9">
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {HVAC1_PDRSAug24_PDRS__postcode, HVAC1_PDRSAug24_BCA_Climate_Zone} from '../../types/openfisca_variables';
 
 export default function CertificateEstimatorResidentialACLoadClauses(props) {
   const {
@@ -177,13 +178,15 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
         ) {
           formItem.form_value = metadata['Rated ACOP'];
         }
-        if (formItem.name === 'HVAC1_PDRSAug24_PDRS__postcode') {
+        if (formItem.name === HVAC1_PDRSAug24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
-        if (formItem.name === 'HVAC1_PDRSAug24_BCA_Climate_Zone') {
+        if (formItem.name === HVAC1_PDRSAug24_BCA_Climate_Zone) {
           formItem.form_value = bca_mapping[selectedClimateZone];
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -219,11 +222,15 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>BCA Climate Zone: </b> {selectedClimateZone.charAt(selectedClimateZone.length - 1)}
+                  </p>
+                  <p>
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -284,11 +291,15 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>BCA Climate Zone: </b> {selectedClimateZone.charAt(selectedClimateZone.length - 1)}
+                  </p>
+                  <p>
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -368,7 +368,7 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 prcMinPrice={prcMinPrice}
                 prcMaxPrice={prcMaxPrice}
               />
-              <div className="nsw-col-md-9">
+              <div className="nsw-col-md-9" style={{marginTop: '1.5rem'}}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {HVAC1_PDRSAug24_PDRS__postcode, HVAC1_PDRSAug24_BCA_Climate_Zone} from '../../types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorResidentialACLoadClauses(props) {
   const {
@@ -311,37 +312,31 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                   {/* </h4> */}
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   and your PRCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult))}</b>
                   </span>
                   {/* </h4> */}
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult) === 0
-                        ? 0
-                        : Math.round(peakDemandReductionSavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult) === 0
+                      ? 0
+                      : formatNumber(Math.round(peakDemandReductionSavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
 
                 <p>

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -368,7 +368,7 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                 prcMinPrice={prcMinPrice}
                 prcMaxPrice={prcMaxPrice}
               />
-              <div className="nsw-col-md-9" style={{marginTop: '1.5rem'}}>
+              <div className="nsw-col-md-9" style={{marginTop: '1.25rem'}}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
+++ b/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
@@ -109,7 +109,7 @@ export default function ActivityRequirementsRF1(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
+++ b/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
@@ -109,7 +109,7 @@ export default function ActivityRequirementsRF1(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
+++ b/src/pages/residential_refrigerators/ActivityRequirementsRF1.jsx
@@ -143,7 +143,7 @@ export default function ActivityRequirementsRF1(props) {
           </div>
         )}
 
-        {stepNumber === 2 && (
+        {!IS_DRUPAL_PAGES && stepNumber === 2 && (
           <div className="nsw-grid nsw-grid--spaced">
             <div className="nsw-col nsw-col-md-12">
               <h2 className="nsw-content-block__title">

--- a/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
@@ -22,6 +22,8 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
     entities,
     setStepNumber,
     stepNumber,
+    postcode,
+    setPostcode,
     metadata,
     calculationError,
     calculationError2,
@@ -151,6 +153,7 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
               calculationError2={calculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              setPostcode={setPostcode}
               formValues={formValues}
               setFormValues={setFormValues}
               backAction={(e) => {
@@ -179,6 +182,19 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
 
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
+            <div
+              className="nsw-global-alert nsw-global-alert--light js-global-alert"
+              role="alert"
+              style={{ width: '80%', marginBottom: '7%' }}
+            >
+              <div className="nsw-global-alert__wrapper">
+                <div className="nsw-global-alert__content">
+                  <p>
+                    <b>Postcode: </b> {postcode}
+                  </p>
+                </div>
+              </div>
+            </div>
             {
               <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>

--- a/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
@@ -13,6 +13,7 @@ import { FormGroup, Select } from '../../nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesRefrigerators(props) {
   const {
@@ -200,19 +201,16 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
                 <p>
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates

--- a/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
@@ -12,6 +12,7 @@ import Alert from 'nsw-ds-react/alert/alert';
 import { FormGroup, Select } from '../../nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import { updateSegmentCaptureAnalytics } from 'lib/analytics';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesRefrigerators(props) {
   const {
@@ -48,6 +49,8 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
     setPeakDemandReductionSavingsNumber,
     userType,
     setUserType,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   useEffect(() => {
@@ -177,7 +180,7 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
         {stepNumber === 2 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
@@ -226,11 +229,15 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
@@ -124,7 +124,7 @@ export default function CertificateEstimatorRefrigerators(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (
@@ -169,7 +169,7 @@ export default function CertificateEstimatorRefrigerators(props) {
           </div>
         )}
 
-        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={2} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 2 && loading && !showError && <SpinnerFullscreen />}
 

--- a/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
@@ -199,6 +199,8 @@ export default function CertificateEstimatorRefrigerators(props) {
               setCalculationError2={setCalculationError2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
+              setPostcode={setPostcode}
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
@@ -240,6 +242,7 @@ export default function CertificateEstimatorRefrigerators(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}
@@ -262,26 +265,6 @@ export default function CertificateEstimatorRefrigerators(props) {
               escMaxPrice={escMaxPrice}
             />
           )}
-
-          {stepNumber === 1 && registryData && postcode && postcode.length === 4 && (
-            <div className="nsw-row" style={{ paddingTop: '30px' }}>
-              <div className="nsw-col" style={{ padding: 'inherit', width: '80%' }}>
-                <Button
-                  as="dark"
-                  onClick={(e) => {
-                    setFlow('forward');
-                    setStepNumber(stepNumber + 1);
-                    updateEstimatorFormAnalytics({
-                      sf_postcode: postcode,
-                    });
-                  }}
-                  style={{ float: 'right' }}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
-          )}
         </Fragment>
       </div>
       {stepNumber === 2 && (
@@ -297,14 +280,10 @@ export default function CertificateEstimatorRefrigerators(props) {
                   marginBottom: '5%',
                 }}
               >
-                <MoreOptionsCard
-                  options={[
-                    {
-                      title: 'Review eligibility for this activity',
-                      link: '/#residential-refrigeration-activity-requirements',
-                    },
-                  ]}
-                />
+                <MoreOptionsCard options={[{
+                  title: 'Review eligibility for this activity',
+                  link: '/#residential-refrigeration-activity-requirements'
+                }]}/>
               </div>
             </div>
           )}

--- a/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorRefrigerators.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react';
 import { ProgressIndicator } from 'nsw-ds-react/forms/progress-indicator/progressIndicator';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaAPI from 'services/openfisca_api';
+import RegistryApi from 'services/registry_api';
 import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import CertificateEstimatorLoadClausesRefrigerators from './CertificateEstimatorLoadClausesRefrigerators';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
@@ -40,6 +41,8 @@ export default function CertificateEstimatorRefrigerators(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -88,6 +91,20 @@ export default function CertificateEstimatorRefrigerators(props) {
       .catch((err) => {
         console.log(err);
       });
+  }, []);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
   }, []);
 
   return (
@@ -203,6 +220,8 @@ export default function CertificateEstimatorRefrigerators(props) {
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               userType={userType}
               setUserType={setUserType}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -239,6 +258,8 @@ export default function CertificateEstimatorRefrigerators(props) {
               setPeakDemandReductionSavingsNumber={setPeakDemandReductionSavingsNumber}
               userType={userType}
               setUserType={setUserType}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/residential_solar_water_heater_D18/ActivityRequirementsD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/ActivityRequirementsD18.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsD18(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_solar_water_heater_D18/ActivityRequirementsD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/ActivityRequirementsD18.jsx
@@ -128,7 +128,7 @@ export default function ActivityRequirementsD18(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
@@ -115,6 +115,7 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
@@ -478,6 +478,7 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -202,6 +204,20 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -413,6 +429,8 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -472,6 +490,8 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
               setLoading={setLoading}
               showError={showError}
               setShowError={setShowError}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorD18.jsx
@@ -237,7 +237,7 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -291,7 +291,7 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
           </div>
         )} */}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -503,7 +503,7 @@ export default function CertificateEstimatorResidentialSolarWaterHeater(props) {
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D18_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 export default function CertificateEstimatorLoadClausesD18(props) {
   const {
@@ -134,9 +135,10 @@ export default function CertificateEstimatorLoadClausesD18(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D18_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D18_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -180,11 +182,12 @@ export default function CertificateEstimatorLoadClausesD18(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -245,11 +248,12 @@ export default function CertificateEstimatorLoadClausesD18(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
+                  <b>Brand: </b> {selectedBrand}
+                </p>
+                <p>
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
@@ -8,6 +8,7 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 
 export default function CertificateEstimatorLoadClausesD18(props) {
   const {
@@ -46,6 +47,8 @@ export default function CertificateEstimatorLoadClausesD18(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -257,7 +260,7 @@ export default function CertificateEstimatorLoadClausesD18(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -306,11 +309,15 @@ export default function CertificateEstimatorLoadClausesD18(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
@@ -10,6 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {D18_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesD18(props) {
   const {
@@ -269,19 +270,16 @@ export default function CertificateEstimatorLoadClausesD18(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/ActivityRequirementsD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/ActivityRequirementsD20.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD20(props) {
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/ActivityRequirementsD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/ActivityRequirementsD20.jsx
@@ -129,7 +129,7 @@ export default function ActivityRequirementsD20(props) {
         </div>
       )}
 
-      <div className="nsw-container" style={{ marginTop: '1rem' }}>
+      <div className="nsw-container">
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 2 && (

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
@@ -478,6 +478,7 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
               setCalculationResult2={setCalculationResult2}
               stepNumber={stepNumber}
               setStepNumber={setStepNumber}
+              postcode={postcode}
               formValues={formValues}
               setFormValues={setFormValues}
               persistFormValues={persistFormValues}

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
@@ -235,7 +235,7 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
         </div>
       )}
 
-      <div className="nsw-container">
+      <div className="nsw-container" style={{ paddingLeft: 0 }}>
         <br></br>
         <br></br>
         {!IS_DRUPAL_PAGES && stepNumber !== 3 && (
@@ -290,7 +290,7 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
           </div>
         )} */}
 
-        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%' }} />
+        <ProgressIndicator step={stepNumber} of={3} style={{ width: '80%', marginTop: '3rem' }} />
 
         {stepNumber === 3 && loading && !showError && <SpinnerFullscreen />}
 
@@ -503,7 +503,7 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
             selectedBrand &&
             selectedModel &&
             userType && (
-              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%' }}>
+              <div className="nsw-row" style={{ paddingTop: '30px', width: '80%', marginBottom: 70 }}>
                 <div className="nsw-col" style={{ padding: 'inherit' }}>
                   <Button
                     as="dark"

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
@@ -49,6 +49,8 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
   const [annualEnergySavingsNumber, setAnnualEnergySavingsNumber] = useState(0);
   const [peakDemandReductionSavingsNumber, setPeakDemandReductionSavingsNumber] = useState(0);
   const [userType, setUserType] = useState('');
+  const [escMinPrice, setEscMinPrice] = useState(0);
+  const [escMaxPrice, setEscMaxPrice] = useState(0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -201,6 +203,20 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
         console.log(err);
       });
   }, [postcode]);
+
+  useEffect(() => {
+    const fetchCertificatePrice = async function () {
+      try {
+        const response = await RegistryApi.getCertificatePrice()
+        setEscMinPrice(Number(response.data.ESC.min_price))
+        setEscMaxPrice(Number(response.data.ESC.max_price))
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    fetchCertificatePrice()
+  }, []);
 
   return (
     <Fragment>
@@ -413,6 +429,8 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
               backAction={(e) => {
                 setStepNumber(stepNumber - 1);
               }}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 
@@ -472,6 +490,8 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
               setLoading={setLoading}
               showError={showError}
               setShowError={setShowError}
+              escMinPrice={escMinPrice}
+              escMaxPrice={escMaxPrice}
             />
           )}
 

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorD20.jsx
@@ -115,6 +115,7 @@ export default function CertificateEstimatorResidentialGasReplacementSolarWaterH
           ) {
             if (persons.data['state'] === 'NSW') {
               setShowPostcodeError(false);
+              setShowNoResponsePostcodeError(false);
               setFlow(null);
               setStepNumber(stepNumber + 1);
             } else {

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
@@ -9,6 +9,7 @@ import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+import {D20_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
 
 
 export default function CertificateEstimatorLoadClausesD20(props) {
@@ -133,9 +134,10 @@ export default function CertificateEstimatorLoadClausesD20(props) {
           formItem.form_value = metadata[`Bs_annual_supplementary_energy_zone_${zone}`];
         }
 
-        if (formItem.name === 'D20_ESSJun24_PDRS__postcode') {
+        if (formItem.name === D20_ESSJun24_PDRS__postcode) {
           formItem.form_value = postcode;
           formItem.read_only = true;
+          formItem.hide = true;
         }
       });
 
@@ -179,11 +181,12 @@ export default function CertificateEstimatorLoadClausesD20(props) {
                 <div class="nsw-global-alert__content">
                   {/* <div class="nsw-global-alert__title"></div> */}
                   <p>
-                    {' '}
-                    <b>Brand: </b> {selectedBrand}{' '}
+                    <b>Postcode: </b> {postcode}
                   </p>
                   <p>
-                    {' '}
+                    <b>Brand: </b> {selectedBrand}
+                  </p>
+                  <p>
                     <b>Model: </b> {selectedModel}
                   </p>
                 </div>
@@ -244,11 +247,12 @@ export default function CertificateEstimatorLoadClausesD20(props) {
               <div class="nsw-global-alert__content">
                 {/* <div class="nsw-global-alert__title"></div> */}
                 <p>
-                  {' '}
-                  <b>Brand: </b> {selectedBrand}{' '}
+                  <b>Postcode: </b> {postcode}
                 </p>
                 <p>
-                  {' '}
+                  <b>Brand: </b> {selectedBrand}
+                </p>
+                <p>
                   <b>Model: </b> {selectedModel}
                 </p>
               </div>

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
@@ -8,6 +8,8 @@ import CalculateBlock from 'components/calculate/CalculateBlock';
 import Button from 'nsw-ds-react/button/button';
 import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
+import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
+
 
 export default function CertificateEstimatorLoadClausesD20(props) {
   const {
@@ -46,6 +48,8 @@ export default function CertificateEstimatorLoadClausesD20(props) {
     setAnnualEnergySavingsNumber,
     peakDemandReductionSavingsNumber,
     setPeakDemandReductionSavingsNumber,
+    escMinPrice,
+    escMaxPrice,
   } = props;
 
   const [variable, setVariable] = useState({}); // all info about variable
@@ -255,7 +259,7 @@ export default function CertificateEstimatorLoadClausesD20(props) {
         {stepNumber === 3 && !calculationError && !calculationError2 && (
           <Fragment>
             {
-              <Alert as="info" title="ESCs" style={{ width: '80%' }}>
+              <Alert as="info" title="ESCs" style={{ width: '80%', marginBottom: '7%' }}>
                 <p>
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
@@ -304,11 +308,15 @@ export default function CertificateEstimatorLoadClausesD20(props) {
               style={{
                 paddingLeft: 'inherit',
                 paddingRight: 'inherit',
-                paddingTop: '30px',
                 width: '80%',
               }}
             >
-              <div className="nsw-col-md-9" style={{ padding: 'inherit' }}>
+              <CertificiatePrice
+                escCertificates={calculationResult2}
+                escMinPrice={escMinPrice}
+                escMaxPrice={escMaxPrice}
+              />
+              <div className="nsw-col-md-9" style={{ marginTop: '1.25rem' }}>
                 <Button
                   style={{ float: 'left' }}
                   as="dark-outline-solid"

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
@@ -10,7 +10,7 @@ import OpenFiscaApi from 'services/openfisca_api';
 import Alert from 'nsw-ds-react/alert/alert';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
 import {D20_ESSJun24_PDRS__postcode} from 'types/openfisca_variables';
-
+import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesD20(props) {
   const {
@@ -268,19 +268,16 @@ export default function CertificateEstimatorLoadClausesD20(props) {
                   {/* <h4 className="nsw-content-block__title" style={{ textAlign: 'center' }}> */}
                   Based on the information provided, your ESCs are
                   <span style={{ fontSize: '25px', paddingLeft: '10px', paddingRight: '10px' }}>
-                    <b>{Math.floor(calculationResult2)}</b>
+                    <b>{formatNumber(Math.floor(calculationResult2))}</b>
                   </span>
                 </p>
                 <p>
                   Your estimated annual energy savings are{' '}
                   <b>
-                    <b>
-                      {Math.floor(calculationResult2) === 0
-                        ? 0
-                        : Math.round(annualEnergySavingsNumber * 100) / 100}
-                    </b>{' '}
-                    kWh{' '}
-                  </b>
+                    {Math.floor(calculationResult2) === 0
+                      ? 0
+                      : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
+                  </b> kWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates

--- a/src/services/registry_api.js
+++ b/src/services/registry_api.js
@@ -212,6 +212,13 @@ function getPostcodeValidation(postcode) {
   });
 }
 
+function getCertificatePrice() {
+  return RegistryApiBase({
+    url: '/certificate-price',
+    method: 'GET',
+  })
+}
+
 const RegistryApi = {
   getCommercialHVACBrands,
   getCommercialHVACLastModified,
@@ -242,6 +249,7 @@ const RegistryApi = {
   getResidentialSolarBatteryBrands,
   getResidentialSolarBatteryModels,
   getResidentialSolarBatteryMetadata,
+  getCertificatePrice,
 };
 
 export default RegistryApi;

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -5,6 +5,17 @@ export const BESS1_PDRSAug24_PDRS__postcode = 'BESS1_PDRSAug24_PDRS__postcode';
 export const BESS2_PDRSAug24_PDRS__postcode = 'BESS2_PDRSAug24_PDRS__postcode';
 export const C1_PDRSAug24_PDRS__postcode = 'C1_PDRSAug24_PDRS__postcode';
 export const F7_PDRSAug24_PDRS__postcode = 'F7_PDRSAug24_PDRS__postcode';
+export const RF2_F1_2_ESSJun24_PDRS__postcode = 'RF2_F1_2_ESSJun24_PDRS__postcode';
+export const HVAC2_PDRSAug24_PDRS__postcode = 'HVAC2_PDRSAug24_PDRS__postcode';
+export const D17_ESSJun24_PDRS__postcode = 'D17_ESSJun24_PDRS__postcode';
+export const D19_ESSJun24_PDRS__postcode = 'D19_ESSJun24_PDRS__postcode';
+export const F16_electric_PDRSDec24_PDRS__postcode = 'F16_electric_PDRSDec24_PDRS__postcode';
+export const F16_gas_PDRS__postcode = 'F16_gas_PDRS__postcode';
+export const F17_ESS__postcode = 'F17_ESS__postcode';
+export const SYS2_PDRSAug24_PDRS__postcode = 'SYS2_PDRSAug24_PDRS__postcode';
+export const HVAC1_PDRSAug24_PDRS__postcode = 'HVAC1_PDRSAug24_PDRS__postcode';
+export const D18_ESSJun24_PDRS__postcode = 'D18_ESSJun24_PDRS__postcode';
+export const D20_ESSJun24_PDRS__postcode = 'D20_ESSJun24_PDRS__postcode';
 
 // Calculation
 export const BESS1_V5Nov24_PRC_calculation = 'BESS1_V5Nov24_PRC_calculation';


### PR DESCRIPTION
# [DG22-2379] Fixing post code field still showing up at step 2 in certificates pages

## Summary
This pull request addresses the following functionality/fixes:
* Use display none inline style instead of using class nsw-display-none

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2379

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None


[DG22-2379]: https://essnsw.atlassian.net/browse/DG22-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ