### PR TITLE
[DG22-2382] change value descriptor from kWh to MWh.

### DIFF
--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -325,7 +325,7 @@ export default function CertificateEstimatorLoadClauses(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}

--- a/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
+++ b/src/pages/commercial_motors/CertificateEstimatorLoadClausesMotors.jsx
@@ -218,7 +218,7 @@ export default function CertificateEstimatorLoadClausesMotors(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
+++ b/src/pages/commercial_wh/CertificateEstimatorLoadClausesWH.jsx
@@ -288,7 +288,7 @@ export default function CertificateEstimatorLoadClausesWH(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
+++ b/src/pages/commercial_wh_F16_gas/CertificateEstimatorLoadClausesF16_gas.jsx
@@ -285,7 +285,7 @@ export default function CertificateEstimatorLoadClausesF16_gas(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
+++ b/src/pages/commercial_wh_f17/CertificateEstimatorLoadClausesF17.jsx
@@ -279,7 +279,7 @@ export default function CertificateEstimatorLoadClausesF17(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
+++ b/src/pages/electric_residential_heat_pumps/CertificateEstimatorLoadClausesD17.jsx
@@ -280,7 +280,7 @@ export default function CertificateEstimatorLoadClausesD17(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates

--- a/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
+++ b/src/pages/gas_residential_heat_pumps/CertificateEstimatorLoadClausesD19.jsx
@@ -279,7 +279,7 @@ export default function CertificateEstimatorLoadClausesD19(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
 
                 <p>

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -299,7 +299,7 @@ export default function CertificateEstimatorLoadClausesPP(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}

--- a/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
+++ b/src/pages/refrigerated_cabinets/CertificatEstimatorLoadClausesRC.jsx
@@ -289,7 +289,7 @@ export default function CertificateEstimatorLoadClausesRC(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}

--- a/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
+++ b/src/pages/residential_ac/CertificateEstimatorResidentialACLoadClauses.jsx
@@ -328,7 +328,7 @@ export default function CertificateEstimatorResidentialACLoadClauses(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   Your estimated annual peak demand reduction is{' '}

--- a/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
+++ b/src/pages/residential_refrigerators/CertificateEstimatorLoadClausesRefrigerators.jsx
@@ -210,7 +210,7 @@ export default function CertificateEstimatorLoadClausesRefrigerators(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates

--- a/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
+++ b/src/pages/residential_solar_water_heater_D18/CertificateEstimatorLoadClausesD18.jsx
@@ -279,7 +279,7 @@ export default function CertificateEstimatorLoadClausesD18(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates

--- a/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
+++ b/src/pages/residential_solar_water_heater_gas_replacement_D20/CertificateEstimatorLoadClausesD20.jsx
@@ -277,7 +277,7 @@ export default function CertificateEstimatorLoadClausesD20(props) {
                     {Math.floor(calculationResult2) === 0
                       ? 0
                       : formatNumber(Math.round(annualEnergySavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> MWh
                 </p>
                 <p>
                   As this activity is only eligible for the Energy Savings Scheme, it generates


### PR DESCRIPTION
# [DG22-2382] change value descriptor from kWh to MWh.

## Summary
This pull request addresses the following functionality/fixes:
* Change value descriptor on all certificate pages result except for BESS1 and BESS2 (only have PRC)

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2382

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None

[DG22-2382]: https://essnsw.atlassian.net/browse/DG22-2382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ