### PR TITLE
[DG22-2386] UI change: hookup RF2 conditional questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@fontsource/montserrat": "^4.2.2",
     "@fontsource/public-sans": "^4.5.11",
     "@material-ui/core": "^4.11.3",
-    "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "axios": "^1.4.0",

--- a/src/components/calculate/CalculateBlock.js
+++ b/src/components/calculate/CalculateBlock.js
@@ -15,6 +15,9 @@ import {
   SYS2_PDRSAug24_new_installation_or_replacement,
   HVAC1_PDRSAug24_new_installation_or_replacement,
   HVAC2_new_installation_or_replacement,
+  RF2_F1_2_ESSJun24_GEMS_product_class_5,
+  RF2_F1_2_ESSJun24_EEI_under_51,
+  RF2_F1_2_ESSJun24_EEI_under_81,
 } from 'types/openfisca_variables';
 
 export default function CalculateBlock(props) {
@@ -334,13 +337,13 @@ export default function CalculateBlock(props) {
         }
       }
 
-      if (formItem.name === 'RF2_GEMS_product_class_5') {
+      if (formItem.name === RF2_F1_2_ESSJun24_GEMS_product_class_5) {
         if (e.target.value === 'true') {
-          formValues.find((v) => v.name === 'RF2_EEI_under_51').hide = false;
-          formValues.find((v) => v.name === 'RF2_EEI_under_81').hide = true;
+          formValues.find((v) => v.name === RF2_F1_2_ESSJun24_EEI_under_51).hide = false;
+          formValues.find((v) => v.name === RF2_F1_2_ESSJun24_EEI_under_81).hide = true;
         } else {
-          formValues.find((v) => v.name === 'RF2_EEI_under_51').hide = true;
-          formValues.find((v) => v.name === 'RF2_EEI_under_81').hide = false;
+          formValues.find((v) => v.name === RF2_F1_2_ESSJun24_EEI_under_51).hide = true;
+          formValues.find((v) => v.name === RF2_F1_2_ESSJun24_EEI_under_81).hide = false;
         }
       }
 

--- a/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
+++ b/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
@@ -9,6 +9,7 @@ import LoadClausesRF2 from './LoadClauses';
 import { IS_DRUPAL_PAGES } from 'types/app_variables';
 import {
   RF2_F1_2_ESSJun24_installation_replacement_final_activity_eligibility,
+  RF2_F1_2_ESSJun24_EEI_under_51,
 } from 'types/openfisca_variables';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
@@ -73,6 +74,10 @@ export default function ActivityRequirementsRF2(props) {
       });
 
       array.sort((a, b) => a.metadata.sorting - b.metadata.sorting);
+
+      const names = [
+        RF2_F1_2_ESSJun24_EEI_under_51,
+      ];
 
       dep_arr = array.filter((item) => names.includes(item.name));
       array.find((item) => {

--- a/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
+++ b/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
@@ -7,6 +7,9 @@ import SpinnerFullscreen from 'components/layout/SpinnerFullscreen';
 import HeroBanner from 'nsw-ds-react/heroBanner/heroBanner';
 import LoadClausesRF2 from './LoadClauses';
 import { IS_DRUPAL_PAGES } from 'types/app_variables';
+import {
+  RF2_F1_2_ESSJun24_installation_replacement_final_activity_eligibility,
+} from 'types/openfisca_variables';
 import { FormGroup, Select } from 'nsw-ds-react/forms';
 import { USER_TYPE_OPTIONS } from 'constant/user-type';
 import {
@@ -26,7 +29,7 @@ export default function ActivityRequirementsRF2(props) {
   const [stepNumber, setStepNumber] = useState(1);
   const [dependencies, setDependencies] = useState([]);
   const [variableToLoad, setVariableToLoad] = useState(
-    'RF2_F1_2_ESSJun24_installation_replacement_final_activity_eligibility',
+    RF2_F1_2_ESSJun24_installation_replacement_final_activity_eligibility,
   );
   const [variable, setVariable] = useState({});
   const [clausesForm, setClausesForm] = useState([]);
@@ -71,13 +74,6 @@ export default function ActivityRequirementsRF2(props) {
 
       array.sort((a, b) => a.metadata.sorting - b.metadata.sorting);
 
-      const names = [
-        'RF2_installation',
-        'RF2_EEI_under_51',
-        'RF2_EEI_under_81',
-        'RF2_legal_disposal',
-      ];
-
       dep_arr = array.filter((item) => names.includes(item.name));
       array.find((item) => {
         if (names.includes(item.name)) {
@@ -101,14 +97,14 @@ export default function ActivityRequirementsRF2(props) {
     formValues
       .filter((x) => x.hide === false)
       .map((child) => {
-        if (
-          child.form_value !== child.default_value &&
-          new_arr.find((o) => o.name === child.name) === undefined &&
-          child.value_type === 'Boolean'
-        )
-          new_arr.push(child);
-        else if (child.form_value !== child.default_value && child.value_type === 'String') {
-          new_arr.push(child);
+        if (child.value_type === 'Boolean') {
+          if (child.form_value === false) {
+            new_arr.push(child);
+          }
+        } else if (child.value_type === 'String') {
+          if (child.form_value !== child.default_value) {
+            new_arr.push(child);
+          }
         }
       });
     setClausesForm(new_arr);

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -94,3 +94,10 @@ export const SYS2_PDRSAug24_new_installation_or_replacement =
 
 // CORE ELIGIBILITY
 export const ESS__PDRS__ACP_base_scheme_eligibility = 'ESS__PDRS__ACP_base_scheme_eligibility';
+
+// REFRIGERATED CABINETS ELIGIBILITY
+export const RF2_F1_2_ESSJun24_installation_replacement_final_activity_eligibility =
+  'RF2_F1_2_ESSJun24_installation_replacement_final_activity_eligibility';
+export const RF2_F1_2_ESSJun24_GEMS_product_class_5 = 'RF2_F1_2_ESSJun24_GEMS_product_class_5';
+export const RF2_F1_2_ESSJun24_EEI_under_51 = 'RF2_F1_2_ESSJun24_EEI_under_51';
+export const RF2_F1_2_ESSJun24_EEI_under_81 = 'RF2_F1_2_ESSJun24_EEI_under_81';


### PR DESCRIPTION
# [DG22-2386] Fix flow in ui eligibility F.12/RF2 Refrigerated cabinet 

## Summary
This pull request addresses the following functionality/fixes:
* Update variable to use the latest one from openfisca instead using the old one.
* Fix flow ui to display Q10, Q11, Q12 in F1.2/RF2 eligibility page
* Fix logic to display F1.2/RF2 eligibility clause
* remove unncesscary dependecies that causing build failed. (due to the outdated node version)

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2386

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None

[DG22-2386]: https://essnsw.atlassian.net/browse/DG22-2386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ