### PR TITLE
[DG22-2477] - D5/SYS2 certificates UI: Maximum Tested Input Power instead of Nameplate Input Power

### DIFF
--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -13,7 +13,8 @@ import {
   SYS2_PDRSAug24_PDRS__postcode,
   SYS2_PDRSAug24_maximum_tested_input_power,
   SYS2_PDRSAug24_daily_run_time,
-  SYS2_PDRSAug24_projected_annual_energy_consumption
+  SYS2_PDRSAug24_projected_annual_energy_consumption,
+  SYS2_PDRSAug24_nameplate_input_power
 } from 'types/openfisca_variables';
 import { formatNumber } from 'lib/helper';
 
@@ -152,6 +153,13 @@ export default function CertificateEstimatorLoadClausesPP(props) {
           };
 
           formItem.form_value = dic[metadata['star_rating']];
+        }
+
+        // SYS2_PDRSAug24_nameplate_input_power didn't exist in openfisca anymore
+        // but it still exist on djangoAPI, so we need to hide it for now.
+        //TODO: remove this when SYS2_PDRSAug24_nameplate_input_power is removed from djangoAPI
+        if (formItem.name === SYS2_PDRSAug24_nameplate_input_power) {
+          formItem.hide = true;
         }
 
         if (formItem.name === SYS2_PDRSAug24_maximum_tested_input_power) {

--- a/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
+++ b/src/pages/pool_pumps/CertificateEstimatorLoadClausesPP.jsx
@@ -9,7 +9,12 @@ import Button from 'nsw-ds-react/button/button';
 import { Alert } from 'nsw-ds-react/alert/alert';
 import OpenFiscaApi from 'services/openfisca_api';
 import CertificiatePrice from 'components/certificate-price/CertificiatePrice';
-import {SYS2_PDRSAug24_PDRS__postcode} from 'types/openfisca_variables';
+import {
+  SYS2_PDRSAug24_PDRS__postcode,
+  SYS2_PDRSAug24_maximum_tested_input_power,
+  SYS2_PDRSAug24_daily_run_time,
+  SYS2_PDRSAug24_projected_annual_energy_consumption
+} from 'types/openfisca_variables';
 import { formatNumber } from 'lib/helper';
 
 export default function CertificateEstimatorLoadClausesPP(props) {
@@ -149,15 +154,15 @@ export default function CertificateEstimatorLoadClausesPP(props) {
           formItem.form_value = dic[metadata['star_rating']];
         }
 
-        if (formItem.name === 'SYS2_PDRSAug24_nameplate_input_power') {
+        if (formItem.name === SYS2_PDRSAug24_maximum_tested_input_power) {
           formItem.form_value = metadata['input_power'];
         }
 
-        if (formItem.name === 'SYS2_PDRSAug24_daily_run_time') {
+        if (formItem.name === SYS2_PDRSAug24_daily_run_time) {
           formItem.form_value = metadata['daily_run_time'];
         }
 
-        if (formItem.name === 'SYS2_PDRSAug24_projected_annual_energy_consumption') {
+        if (formItem.name === SYS2_PDRSAug24_projected_annual_energy_consumption) {
           formItem.form_value = metadata['labelled_energy_consumption'];
         }
 

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -119,10 +119,11 @@ export const F7_PDRSAug24_ESC_calculation = 'F7_PDRSAug24_ESC_calculation';
 export const F7_PDRSAug24_energy_savings = 'F7_PDRSAug24_energy_savings';
 
 // POOL PUMPS
-export const SYS2_PDRSAug24_replacement_final_activity_eligibility =
-  'SYS2_PDRSAug24_replacement_final_activity_eligibility';
-export const SYS2_PDRSAug24_new_installation_or_replacement =
-  'SYS2_PDRSAug24_new_installation_or_replacement';
+export const SYS2_PDRSAug24_replacement_final_activity_eligibility = 'SYS2_PDRSAug24_replacement_final_activity_eligibility';
+export const SYS2_PDRSAug24_new_installation_or_replacement = 'SYS2_PDRSAug24_new_installation_or_replacement';
+export const SYS2_PDRSAug24_maximum_tested_input_power = 'SYS2_PDRSAug24_maximum_tested_input_power';
+export const SYS2_PDRSAug24_daily_run_time = 'SYS2_PDRSAug24_daily_run_time';
+export const SYS2_PDRSAug24_projected_annual_energy_consumption = 'SYS2_PDRSAug24_projected_annual_energy_consumption';
 
 // CORE ELIGIBILITY
 export const ESS__PDRS__ACP_base_scheme_eligibility = 'ESS__PDRS__ACP_base_scheme_eligibility';

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -124,6 +124,7 @@ export const SYS2_PDRSAug24_new_installation_or_replacement = 'SYS2_PDRSAug24_ne
 export const SYS2_PDRSAug24_maximum_tested_input_power = 'SYS2_PDRSAug24_maximum_tested_input_power';
 export const SYS2_PDRSAug24_daily_run_time = 'SYS2_PDRSAug24_daily_run_time';
 export const SYS2_PDRSAug24_projected_annual_energy_consumption = 'SYS2_PDRSAug24_projected_annual_energy_consumption';
+export const SYS2_PDRSAug24_nameplate_input_power = 'SYS2_PDRSAug24_nameplate_input_power';
 
 // CORE ELIGIBILITY
 export const ESS__PDRS__ACP_base_scheme_eligibility = 'ESS__PDRS__ACP_base_scheme_eligibility';


### PR DESCRIPTION
## Summary
This pull request addresses the following functionality/fixes:
* use maximum tested input power field instead of nameplate input power
* hide nameplate input power
* change hardcoded variable into a constant

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2477

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None
