### PR TITLE
[DG22-2510] - Bug fix: HVAC2 certificates shows 0 annual peak demand reduction for non-zero PRCs

### DIFF
--- a/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
+++ b/src/pages/commercial_ac/CertificatEstimatorLoadClauses.jsx
@@ -333,7 +333,7 @@ export default function CertificateEstimatorLoadClauses(props) {
                     {Math.floor(calculationResult) === 0
                       ? 0
                       : formatNumber(Math.round(peakDemandReductionSavingsNumber * 100) / 100)}
-                  </b> kWh
+                  </b> kW
                 </p>
                 <p>
                   If you are receiving an estimation of 0 certificates, the brand and model may not

--- a/src/pages/commercial_ac/CertificateEstimator.jsx
+++ b/src/pages/commercial_ac/CertificateEstimator.jsx
@@ -239,13 +239,13 @@ export default function CertificateEstimatorHVAC(props) {
   }, [selectedBrand]);
 
   useEffect(() => {
-    if (parseInt(calculationResult) === 0) {
+    if (parseInt(calculationResult2) === 0) {
       setAnnualEnergySavingsNumber(0);
     }
   }, [calculationResult]);
 
   useEffect(() => {
-    if (parseInt(calculationResult2) === 0) {
+    if (parseInt(calculationResult) === 0) {
       setPeakDemandReductionSavingsNumber(0);
     }
   }, [calculationResult2]);


### PR DESCRIPTION
## Summary
This pull request addresses the following functionality/fixes:
* change reference when setting annual energy savings and peak demand reduction savings
* change peak demand reduction saving unit from kWh to kW

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2510

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None
