### PR TITLE
[DG22-2514] - F1.1&F1.2/RF2 eligibility: Frontend and UI

### DIFF
--- a/src/components/calculate/CalculateBlock.js
+++ b/src/components/calculate/CalculateBlock.js
@@ -28,7 +28,13 @@ import {
   D17_ESSJun24_split_system,
   D17_ESSJun24_safety_requirement,
   D19_ESSJun24_split_system,
-  D19_ESSJun24_safety_requirement
+  D19_ESSJun24_safety_requirement,
+  RF2_F1_2_ESSJun24_equipment_replaced,
+  RF2_F1_2_ESSJun24_same_product_class,
+  RF2_F1_2_ESSJun24_qualified_install_removal,
+  RF2_F1_2_ESSJun24_legal_disposal,
+  RF2_F1_2_ESSJun24_EEI_under_77,
+  RF2_F1_2_ESSJun24_EEI_under_81
 } from 'types/openfisca_variables';
 
 export default function CalculateBlock(props) {
@@ -156,20 +162,6 @@ export default function CalculateBlock(props) {
         removeItem(formValues, 'F7_PDRSAug24_existing_equipment_motor_frequency');
         removeItem(formValues, 'F7_PDRSAug24_existing_equipment_no_of_poles');
       }
-    }
-
-    if (
-      formItem.name === 'RF2_equipment_replaced' &&
-      (formItem.form_value === false || formItem.default_value === false)
-    ) {
-      formValues.find((v) => v.name === 'RF2_installation').hide = false;
-      formValues.find((v) => v.name === 'RF2_legal_disposal').hide = true;
-    } else if (
-      formItem.name === 'RF2_equipment_replaced' &&
-      (formItem.form_value === true || formItem.default_value === true)
-    ) {
-      formValues.find((v) => v.name === 'RF2_installation').hide = true;
-      formValues.find((v) => v.name === 'RF2_legal_disposal').hide = false;
     }
 
     if (
@@ -395,22 +387,43 @@ export default function CalculateBlock(props) {
         }
       }
 
-      // cooling capacity path
-      if (formItem.name === 'RF2_equipment_replaced') {
-        if (e.target.value === 'true') {
-          formValues.find((v) => v.name === 'RF2_installation').hide = true;
-        } else {
-          formValues.find((v) => v.name === 'RF2_installation').hide = false;
-        }
-      }
-
-      if (formItem.name === 'RF2_GEMS_product_class_5') {
-        if (e.target.value === 'true') {
-          formValues.find((v) => v.name === 'RF2_EEI_under_51').hide = false;
-          formValues.find((v) => v.name === 'RF2_EEI_under_81').hide = true;
-        } else {
-          formValues.find((v) => v.name === 'RF2_EEI_under_51').hide = true;
-          formValues.find((v) => v.name === 'RF2_EEI_under_81').hide = false;
+      if (formItem.name === RF2_F1_2_ESSJun24_equipment_replaced) {
+        const question_replacements = [
+          RF2_F1_2_ESSJun24_same_product_class,
+          RF2_F1_2_ESSJun24_qualified_install_removal,
+          RF2_F1_2_ESSJun24_legal_disposal,
+        ]
+        // New installation
+        if (e.target.value === 'false') {
+          formValues.forEach(field => {
+            // Hide all questions replacement
+            if (question_replacements.includes(field.name)) {
+              field.hide = true
+            }
+            // Hide question EEI under 81 and show question EEI under 77
+            if (field.name === RF2_F1_2_ESSJun24_EEI_under_77) {
+              field.hide = false
+            }
+            if (field.name === RF2_F1_2_ESSJun24_EEI_under_81) {
+              field.hide = true
+            }
+          })
+          
+        // Replacement
+        } else if (e.target.value === 'true') {
+          formValues.forEach(field => {
+            // Show all questions replacement
+            if (question_replacements.includes(field.name)) {
+              field.hide = false
+            }
+            // Hide question EEI under 77 and show question EEI under 81
+            if (field.name === RF2_F1_2_ESSJun24_EEI_under_77) {
+              field.hide = true
+            }
+            if (field.name === RF2_F1_2_ESSJun24_EEI_under_81) {
+              field.hide = false
+            }
+          })
         }
       }
 

--- a/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
+++ b/src/pages/refrigerated_cabinets/ActivityRequirements.jsx
@@ -15,6 +15,12 @@ import {
   updateSegmentCaptureAnalytics,
   clearSearchCaptureAnalytics,
 } from 'lib/analytics';
+import { 
+  RF2_F1_2_ESSJun24_equipment_replaced,
+  RF2_F1_2_ESSJun24_GEMS_product_class_5,
+  RF2_F1_2_ESSJun24_EEI_under_51,
+  RF2_F1_2_ESSJun24_EEI_under_77
+} from 'types/openfisca_variables';
 import FeedbackComponent from 'components/feedback/feedback';
 import MoreOptionsCard from 'components/more-options-card/more-options-card';
 import { BASE_COMMERCIAL_REFRIGERATED_CABINET_ELIGIBILITY_ANALYTICS_DATA } from 'constant/base-analytics-data';
@@ -72,15 +78,15 @@ export default function ActivityRequirementsRF2(props) {
       array.sort((a, b) => a.metadata.sorting - b.metadata.sorting);
 
       const names = [
-        'RF2_installation',
-        'RF2_EEI_under_51',
-        'RF2_EEI_under_81',
-        'RF2_legal_disposal',
+        RF2_F1_2_ESSJun24_GEMS_product_class_5,
+        RF2_F1_2_ESSJun24_EEI_under_51,
+        RF2_F1_2_ESSJun24_EEI_under_77
       ];
 
       dep_arr = array.filter((item) => names.includes(item.name));
       array.find((item) => {
         if (names.includes(item.name)) {
+          console.log(`item name: ${item.name}`);
           item.hide = true;
         }
       });
@@ -97,6 +103,9 @@ export default function ActivityRequirementsRF2(props) {
 
   useEffect(() => {
     let new_arr = [];
+    const excludeClauses = [
+      RF2_F1_2_ESSJun24_equipment_replaced // replacement or new installation are now eligible
+    ]
 
     formValues
       .filter((x) => x.hide === false)
@@ -104,10 +113,9 @@ export default function ActivityRequirementsRF2(props) {
         if (
           child.form_value !== child.default_value &&
           new_arr.find((o) => o.name === child.name) === undefined &&
-          child.value_type === 'Boolean'
-        )
-          new_arr.push(child);
-        else if (child.form_value !== child.default_value && child.value_type === 'String') {
+          child.value_type === 'Boolean' &&
+          !excludeClauses.includes(child.name)
+        ) {
           new_arr.push(child);
         }
       });

--- a/src/types/openfisca_variables.js
+++ b/src/types/openfisca_variables.js
@@ -134,5 +134,16 @@ export const SYS2_PDRSAug24_daily_run_time = 'SYS2_PDRSAug24_daily_run_time';
 export const SYS2_PDRSAug24_projected_annual_energy_consumption = 'SYS2_PDRSAug24_projected_annual_energy_consumption';
 export const SYS2_PDRSAug24_nameplate_input_power = 'SYS2_PDRSAug24_nameplate_input_power';
 
+// REFRIGERATED CABINET
+export const RF2_F1_2_ESSJun24_equipment_replaced = 'RF2_F1_2_ESSJun24_equipment_replaced';
+export const RF2_F1_2_ESSJun24_same_product_class = 'RF2_F1_2_ESSJun24_same_product_class';
+export const RF2_F1_2_ESSJun24_qualified_install_removal = 'RF2_F1_2_ESSJun24_qualified_install_removal';
+export const RF2_F1_2_ESSJun24_legal_disposal = 'RF2_F1_2_ESSJun24_legal_disposal';
+export const RF2_F1_2_ESSJun24_display_sides = 'RF2_F1_2_ESSJun24_display_sides';
+export const RF2_F1_2_ESSJun24_GEMS_product_class_5 = 'RF2_F1_2_ESSJun24_GEMS_product_class_5';
+export const RF2_F1_2_ESSJun24_EEI_under_51 = 'RF2_F1_2_ESSJun24_EEI_under_51';
+export const RF2_F1_2_ESSJun24_EEI_under_77 = 'RF2_F1_2_ESSJun24_EEI_under_77';
+export const RF2_F1_2_ESSJun24_EEI_under_81 = 'RF2_F1_2_ESSJun24_EEI_under_81';
+
 // CORE ELIGIBILITY
 export const ESS__PDRS__ACP_base_scheme_eligibility = 'ESS__PDRS__ACP_base_scheme_eligibility';


### PR DESCRIPTION
[DG22-2514] Adjust ui flow based on ESS Rule Change 2025

## Summary
This pull request addresses the following functionality/fixes:
* Hide field **_RF2_F1_2_ESSJun24_GEMS_product_class_5_**, **_RF2_F1_2_ESSJun24_EEI_under_51_** since they shouldn't exist in ess rule change 2025
* Replace hardcoded variable into const
* Adjust ui flow on how to display questions

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2514

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None

[DG22-2514]: https://essnsw.atlassian.net/browse/DG22-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ