### PR TITLE
Ignore engine version on CI pipeline for staging and prod

### DIFF
--- a/.github/workflows/build-deploy-prod.yml
+++ b/.github/workflows/build-deploy-prod.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build website
         run: |
           # Install all npm packages
-          yarn install
+          YARN_IGNORE_ENGINES=true yarn install --frozen-lockfile
 
           export REACT_APP_BUILD_VERSION=$(date +'%Y%m%d-%H%M%S')
 

--- a/.github/workflows/build-deploy-staging.yml
+++ b/.github/workflows/build-deploy-staging.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build website
         run: |
           # Install all npm packages
-          yarn install
+          YARN_IGNORE_ENGINES=true yarn install --frozen-lockfile
 
           export REACT_APP_BUILD_VERSION=$(date +'%Y%m%d-%H%M%S')
 


### PR DESCRIPTION
## Summary
This pull request addresses the following functionality/fixes:
* ignore node engine version in CI pipeline

## Links and resources
**Links**
- 

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None
